### PR TITLE
Makefile: don't run the "setup-dev" target in vendor/status-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ STATUSGO := vendor/status-go/build/bin/libstatus.a
 $(STATUSGO): | deps
 	echo -e $(BUILD_MSG) "status-go"
 	+ cd vendor/status-go && \
-	  $(MAKE) setup-dev && \
 	  $(MAKE) statusgo-library
 
 build-linux: $(DOTHERSIDE) $(STATUSGO) src/nim_status_client.nim | deps


### PR DESCRIPTION
That one is too aggressive by trying to install system packages and
seems only relevant for developing status-go itself, not just building
the library like we do here.