### PR TITLE
fix: change onboarding account to whisper key

### DIFF
--- a/src/app/onboarding/view.nim
+++ b/src/app/onboarding/view.nim
@@ -54,8 +54,8 @@ QtObject:
     AddressRoles.Identicon.int:"identicon",
     AddressRoles.Key.int:"key" }.toTable
 
-  proc storeAccountAndLogin(self: OnboardingView, selectedAccountIndex: int, password: string): string {.slot.} =
-    result = self.model.storeAccountAndLogin(selectedAccountIndex, password)
+  proc storeAccountAndLogin(self: OnboardingView, selectedAccountIndex: int, password: string) {.slot.} =
+    discard self.model.storeAccountAndLogin(selectedAccountIndex, password)
 
   # TODO: this is temporary and will be removed once accounts import and creation is working
   proc generateRandomAccountAndLogin*(self: OnboardingView) {.slot.} =

--- a/src/app/profile/profileView.nim
+++ b/src/app/profile/profileView.nim
@@ -1,0 +1,58 @@
+import NimQml
+import mailserversList
+
+QtObject:
+  type ProfileView* = ref object of QObject
+    username*: string
+    identicon*: string
+    mailserversList*: MailServersList
+
+  proc setup(self: ProfileView) =
+    self.QObject.setup
+
+  proc delete*(self: ProfileView) =
+    self.QObject.delete
+
+  proc newProfileView*(): ProfileView =
+    new(result, delete)
+    result.username = ""
+    result.identicon = ""
+    result.mailserversList = newMailServersList()
+    result.setup
+
+  proc username*(self: ProfileView): string {.slot.} =
+    result = self.username
+
+  proc receivedUsername*(self: ProfileView, username: string) {.signal.}
+
+  proc addMailserverToList*(self: ProfileView, name: string, endpoint: string) {.slot.} =
+    self.mailserversList.add(name, endpoint)
+
+  proc setUsername*(self: ProfileView, username: string) {.slot.} =
+    self.username = username
+    self.receivedUsername(username)
+
+  QtProperty[string] username:
+    read = username
+    write = setUsername
+    notify = receivedUsername
+
+  proc identicon*(self: ProfileView): string {.slot.} =
+    result = self.identicon
+
+  proc getMailserversList(self: ProfileView): QVariant {.slot.} =
+    return newQVariant(self.mailserversList)
+
+  QtProperty[QVariant] mailserversList:
+    read = getMailserversList
+
+  proc receivedIdenticon*(self: ProfileView, identicon: string) {.signal.}
+
+  proc setIdenticon*(self: ProfileView, identicon: string) {.slot.} =
+    self.identicon = identicon
+    self.receivedIdenticon(identicon)
+
+  QtProperty[string] identicon:
+    read = identicon
+    write = setIdenticon
+    notify = receivedIdenticon

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -7,7 +7,6 @@ import app/profile/core as profile
 import signals/core as signals
 import app/onboarding/core as onboarding
 import state
-import json
 import status/accounts as status_accounts
 import status/core as status_core
 import status/chat as status_chat
@@ -17,6 +16,7 @@ import models/accounts
 import state
 import status/types
 import eventemitter
+import json_serialization
 
 var signalsQObjPointer: pointer
 
@@ -24,7 +24,7 @@ logScope:
   topics = "main"
 
 proc mainProc() =
-  let nodeAccounts = parseJson(status_accounts.initNodeAccounts()).toNodeAccounts # to be used for login
+  let nodeAccounts = Json.decode(status_accounts.initNodeAccounts(), seq[NodeAccount]) # to be used for login
   let app = newQApplication()
   let engine = newQQmlApplicationEngine()
   let signalController = signals.newController(app)

--- a/src/status/types.nim
+++ b/src/status/types.nim
@@ -1,5 +1,6 @@
-import json
 import eventemitter
+import json_serialization
+import accounts/constants
 
 type SignalCallback* = proc(eventMessage: cstring): void {.cdecl.}
 
@@ -23,54 +24,43 @@ type
     str*: cstring
     length*: cint
 
+type DerivedAccount* = object
+  publicKey*: string
+  address*: string
+
+type MultiAccounts* = object
+  whisper* {.serializedFieldName(PATH_WHISPER).}: DerivedAccount
+  walletRoot* {.serializedFieldName(PATH_WALLET_ROOT).}: DerivedAccount
+  defaultWallet* {.serializedFieldName(PATH_DEFAULT_WALLET).}: DerivedAccount
+  eip1581* {.serializedFieldName(PATH_EIP_1581).}: DerivedAccount
+
+
 type
   Account* = object of RootObj
     name*: string
-    keyUid*: string
-    photoPath*: string
+    keyUid* {.serializedFieldName("key-uid").}: string
+    photoPath* {.serializedFieldName("photo-path").}: string
 
 type
-  NodeAccount* = ref object of Account
+  NodeAccount* = object
     timestamp*: int
-    keycardPairing*: string
+    keycardPairing* {.serializedFieldName("keycard-pairing").}: string
+    # deserialisation does not handle base classes, so flatten
+    name*: string
+    keyUid* {.serializedFieldName("key-uid").}: string
+    photoPath* {.serializedFieldName("photo-path").}: string
 
 type
-  GeneratedAccount* = ref object of Account
+  GeneratedAccount* = object
     publicKey*: string
     address*: string
     id*: string
     mnemonic*: string
-    derived*: JsonNode
-
-proc toNodeAccount*(nodeAccount: JsonNode): NodeAccount =
-  result = NodeAccount(
-    name: nodeAccount["name"].getStr, 
-    timestamp: nodeAccount["timestamp"].getInt,
-    photoPath: nodeAccount["photo-path"].getStr,
-    keycardPairing: nodeAccount["keycard-pairing"].getStr,
-    keyUid: nodeAccount["key-uid"].getStr)
-
-proc toNodeAccounts*(nodeAccounts: JsonNode): seq[NodeAccount] =
-  result = newSeq[NodeAccount]()
-  for v in nodeAccounts:
-    result.add v.toNodeAccount
-
-proc toGeneratedAccount*(generatedAccount: JsonNode): GeneratedAccount =
-  generatedAccount["name"] = %*""
-  generatedAccount["photoPath"] = %*""
-  result = generatedAccount.to(GeneratedAccount)
-
-proc toAccount*(generatedAccount: JsonNode): Account =
-  result = Account(
-    name: generatedAccount["name"].getStr,
-    keyUid: generatedAccount{"key-uid"}.getStr,
-    photoPath: generatedAccount["photo-path"].getStr)
-
-proc toAccount*(generatedAccount: GeneratedAccount): Account =
-  result = Account(
-    name: generatedAccount.name,
-    keyUid: generatedAccount.keyUid,
-    photoPath: generatedAccount.photoPath)
+    derived*: MultiAccounts
+    # deserialisation does not handle base classes, so flatten
+    name*: string
+    keyUid*: string
+    photoPath*: string
 
 type AccountArgs* = ref object of Args
     account*: Account

--- a/ui/onboarding/GenKey.qml
+++ b/ui/onboarding/GenKey.qml
@@ -211,7 +211,7 @@ SwipeView {
                 }
 
                 const selectedAccountIndex = wizardStep2.selectedIndex
-                const storeResponse = onboardingModel.storeAccountAndLogin(selectedAccountIndex, txtPassword.text)
+                onboardingModel.storeAccountAndLogin(selectedAccountIndex, txtPassword.text)
 
                swipeView.loginDone();
             }

--- a/ui/onboarding/OnboardingMain.qml
+++ b/ui/onboarding/OnboardingMain.qml
@@ -54,7 +54,6 @@ Page {
             id: genKeyState
             onEntered: {
                 genKey.visible = true
-                onboardingModel.generateAddresses()
             }
             onExited: genKey.visible = false
 


### PR DESCRIPTION
Previously, the displayed key for generated accounts was displaying the public key of the account, and not the whisper account. This has been fixed.

Futher work has gone in to strongly-typing a lot of the responses from status-go and removed a lot of the manual string parsing.

Simplified types and type-conversions by using the `nim-serialization` library.

Removed the `subaccounts` property from the accounts model as it was no longer being used.