### PR TITLE
fix: remove `onSignal` not overridden warnings

### DIFF
--- a/src/app/onboarding/core.nim
+++ b/src/app/onboarding/core.nim
@@ -4,7 +4,7 @@ import ../../signals/types
 import eventemitter
 import view
 
-type OnboardingController* = ref object of SignalSubscriber
+type OnboardingController* = object
   view*: OnboardingView
   variant*: QVariant
   model*: AccountModel

--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -9,7 +9,7 @@ import view
 import "../../status/types" as status_types
 import ../../models/profile
 
-type ProfileController* = ref object of SignalSubscriber
+type ProfileController* = object
   view*: ProfileView
   variant*: QVariant
   appEvents*: EventEmitter

--- a/src/app/wallet/core.nim
+++ b/src/app/wallet/core.nim
@@ -2,6 +2,7 @@ import NimQml
 import eventemitter
 import strformat
 import strutils
+import chronicles
 
 import view
 import ../../status/wallet as status_wallet
@@ -34,3 +35,7 @@ proc init*(self: WalletController) =
   self.view.addAssetToList(asset)
 
   self.view.setDefaultAccount(status_wallet.getAccount())
+
+method onSignal(self: WalletController, data: Signal) =
+  debug "New signal received"
+  discard


### PR DESCRIPTION
Uninherited `ProfileController` and `OnboardingController` from `SignalSubscriber` as they were not listening for signals from the node.

Added an `onSignal` dummy method in `WalletController` to make the compiler happy. The main app is assuming this is a `SignalSubscriber` but it is unclear if it being used (maybe it's a WIP).