### PR TITLE
feat: get last 20 messages of a channel when joining the chat

### DIFF
--- a/src/models/accounts.nim
+++ b/src/models/accounts.nim
@@ -2,7 +2,6 @@ import eventemitter
 import json_serialization
 import ../status/accounts as status_accounts
 import ../status/types
-import ../status/libstatus
 
 type
   Address* = ref object
@@ -37,15 +36,9 @@ proc generateAddresses*(self: AccountModel): seq[GeneratedAccount] =
 proc generateRandomAccountAndLogin*(self: AccountModel) =
   let generatedAccounts = status_accounts.generateAddresses()
   let account = status_accounts.setupAccount(generatedAccounts[0], "qwerty")
-  # TODO this is needed for now for the retrieving of past messages. We'll either move or remove it later
-  let peer = "enode://44160e22e8b42bd32a06c1532165fa9e096eebedd7fa6d6e5f8bbef0440bc4a4591fe3651be68193a7ec029021cdb496cfe1d7f9f1dc69eb99226e6f39a7a5d4@35.225.221.245:443"
-  discard libstatus.addPeer(peer)
   self.events.emit("accountsReady", AccountArgs(account: account))
 
 proc storeAccountAndLogin*(self: AccountModel, selectedAccountIndex: int, password: string): Account =
   let generatedAccount: GeneratedAccount = self.generatedAddresses[selectedAccountIndex]
   result = status_accounts.setupAccount(generatedAccount, password)
-  # TODO this is needed for now for the retrieving of past messages. We'll either move or remove it later
-  let peer = "enode://44160e22e8b42bd32a06c1532165fa9e096eebedd7fa6d6e5f8bbef0440bc4a4591fe3651be68193a7ec029021cdb496cfe1d7f9f1dc69eb99226e6f39a7a5d4@35.225.221.245:443"
-  discard libstatus.addPeer(peer)
   self.events.emit("accountsReady", AccountArgs(account: result))

--- a/src/models/accounts.nim
+++ b/src/models/accounts.nim
@@ -2,6 +2,7 @@ import eventemitter
 import json_serialization
 import ../status/accounts as status_accounts
 import ../status/types
+import ../status/libstatus
 
 type
   Address* = ref object
@@ -36,9 +37,15 @@ proc generateAddresses*(self: AccountModel): seq[GeneratedAccount] =
 proc generateRandomAccountAndLogin*(self: AccountModel) =
   let generatedAccounts = status_accounts.generateAddresses()
   let account = status_accounts.setupAccount(generatedAccounts[0], "qwerty")
+  # TODO this is needed for now for the retrieving of past messages. We'll either move or remove it later
+  let peer = "enode://44160e22e8b42bd32a06c1532165fa9e096eebedd7fa6d6e5f8bbef0440bc4a4591fe3651be68193a7ec029021cdb496cfe1d7f9f1dc69eb99226e6f39a7a5d4@35.225.221.245:443"
+  discard libstatus.addPeer(peer)
   self.events.emit("accountsReady", AccountArgs(account: account))
 
 proc storeAccountAndLogin*(self: AccountModel, selectedAccountIndex: int, password: string): Account =
   let generatedAccount: GeneratedAccount = self.generatedAddresses[selectedAccountIndex]
   result = status_accounts.setupAccount(generatedAccount, password)
+  # TODO this is needed for now for the retrieving of past messages. We'll either move or remove it later
+  let peer = "enode://44160e22e8b42bd32a06c1532165fa9e096eebedd7fa6d6e5f8bbef0440bc4a4591fe3651be68193a7ec029021cdb496cfe1d7f9f1dc69eb99226e6f39a7a5d4@35.225.221.245:443"
+  discard libstatus.addPeer(peer)
   self.events.emit("accountsReady", AccountArgs(account: result))

--- a/src/status/accounts.nim
+++ b/src/status/accounts.nim
@@ -130,4 +130,8 @@ proc setupAccount*(account: GeneratedAccount, password: string): Account =
   let accountData = getAccountData(account, alias, identicon)
   var settingsJSON = getAccountSettings(account, alias, identicon, multiAccounts, constants.DEFAULT_NETWORKS)
 
-  saveAccountAndLogin(multiAccounts, alias, identicon, $accountData, password, $constants.NODE_CONFIG, $settingsJSON)
+  result = saveAccountAndLogin(multiAccounts, alias, identicon, $accountData, password, $constants.NODE_CONFIG, $settingsJSON)
+
+  # TODO this is needed for now for the retrieving of past messages. We'll either move or remove it later
+  let peer = "enode://44160e22e8b42bd32a06c1532165fa9e096eebedd7fa6d6e5f8bbef0440bc4a4591fe3651be68193a7ec029021cdb496cfe1d7f9f1dc69eb99226e6f39a7a5d4@35.225.221.245:443"
+  discard libstatus.addPeer(peer)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -13,7 +13,8 @@ proc loadFilters*(chatId: string, filterId: string = "", symKeyId: string = "", 
       "SymKeyID": symKeyId, # symmetric key id used for symmetric filters
       "OneToOne": oneToOne, # if asymmetric encryption is used for this chat
       "Identity": identity, # public key of the other recipient for non-public filters.
-      "Topic": topic, # whisper topic
+      # FIXME: passing empty string to the topic makes it error
+      # "Topic": topic, # whisper topic
       "Discovery": discovery, 
       "Negotiated": negotiated,
       "Listen": listen # whether we are actually listening for messages on this chat, or the filter is only created in order to be able to post on the topic

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -1,9 +1,12 @@
 import core
 import json
 import utils
+import times
+import strutils
+import chronicles
 
-proc loadFilters*(chatId: string, filterId: string = "", symKeyId: string = "", oneToOne: bool = false, identity: string = "", topic: string = "", discovery: bool = false, negotiated: bool = false, listen: bool = true) =
-  discard callPrivateRPC("loadFilters".prefix, %* [
+proc loadFilters*(chatId: string, filterId: string = "", symKeyId: string = "", oneToOne: bool = false, identity: string = "", topic: string = "", discovery: bool = false, negotiated: bool = false, listen: bool = true): string =
+  result =  callPrivateRPC("loadFilters".prefix, %* [
     [{
       "ChatID": chatId, # identifier of the chat
       "FilterID": filterId, # whisper filter id generated
@@ -27,6 +30,7 @@ proc saveChat*(chatId: string, oneToOne = false) =
       "active": true,
       "id": chatId,
       "unviewedMessagesCount": 0,
+      # TODO use constants for those too or use the Date
       "chatType":  if oneToOne: 1 else: 2,
       "timestamp": 1588940692659
     }
@@ -34,6 +38,27 @@ proc saveChat*(chatId: string, oneToOne = false) =
 
 proc chatMessages*(chatId: string) =
   discard callPrivateRPC("chatMessages".prefix, %* [chatId, nil, 20])
+
+# TODO this probably belongs in another file
+proc generateSymKeyFromPassword*(): string =
+  result = ($parseJson(callPrivateRPC("waku_generateSymKeyFromPassword", %* [
+    # TODO unhardcode this for non-status mailservers
+    "status-offline-inbox"
+  ]))["result"]).strip(chars = {'"'})
+
+proc requestMessages*(topics: seq[string], symKeyID: string, peer: string, numberOfMessages: int) =
+  discard callPrivateRPC("requestMessages".prefix, %* [
+    {
+        "topics": topics,
+        "mailServerPeer": peer,
+        "symKeyID": symKeyID,
+        "timeout": 30,
+        "limit": numberOfMessages,
+        "cursor": nil,
+        "from": times.toUnix(times.getTime()) - 30000 # Unhardcode this. Need to keep the last fetch in a DB
+    }
+  ])
+
 
 proc sendChatMessage*(chatId: string, msg: string): string =
   callPrivateRPC("sendChatMessage".prefix, %* [


### PR DESCRIPTION
Fixes #60

Makes it possible to get the last 20 messages from a channel when joining that channel.

Known issue: the messages will **not** be ordered. It needs a small adjustment to how we get new messages.

Just showing that all of this was on load: 
![image](https://user-images.githubusercontent.com/11926403/82839362-1b1a8b80-9e9d-11ea-913a-ab8c929fa525.png)
