### PR TITLE
fix: Inability to select generated account

### DIFF
--- a/ui/onboarding/GenKey.qml
+++ b/ui/onboarding/GenKey.qml
@@ -52,12 +52,11 @@ SwipeView {
 
                              Row {
                                RadioButton {
-                                 // checked: index == 0 ? true : false
-                                 checked: false
+                                 checked: index == 0 ? true : false
                                  ButtonGroup.group: accountGroup
-                                 // onClicked: {
-                                   // wizardStep2.selectedIndex = index;
-                                 // }
+                                 onClicked: {
+                                   wizardStep2.selectedIndex = index;
+                                 }
                                }
                                Column {
                                  Image {


### PR DESCRIPTION
Selecting a generated account other than the first one in the list would always use the first generated account.

Uncomment commented-out code that updates the selected index in the view.