### PR TITLE
fix(chat): ensure chatType is set properly

### DIFF
--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -81,8 +81,7 @@ proc join*(self: ChatModel, chatId: string, chatTypeInt: ChatType, isNewChat: bo
 proc load*(self: ChatModel) =
   let chatList = status_chat.loadChats()
   for chat in chatList:
-    # TODO: use correct type of chat instead of hardcoded 2 (assumes it's only public chats)
-    self.join(chat.id, ChatType.Public, false)
+    self.join(chat.id, chat.chatType, false)
   self.events.emit("chatsLoaded", ChatArgs(chats: chatList))
 
 proc leave*(self: ChatModel, chatId: string) =


### PR DESCRIPTION
In ebd29d9ffd6d1981160c82a26d35be602b9231a3 we've introduced a regression where
the channel list didn't expose the chat's chatType to the view, causing 1-on-1 chats
identicons to break.

This commit reintrodruces the chatType to the view.