### PR TITLE
fix: small onboarding/login fixes and feats

### DIFF
--- a/src/app/login/core.nim
+++ b/src/app/login/core.nim
@@ -26,10 +26,10 @@ proc init*(self: LoginController, nodeAccounts: seq[NodeAccount]) =
 
 proc handleNodeLogin(self: LoginController, data: Signal) =
   let response = NodeSignal(data)
-  if self.status.accounts.currentLoginAccount != nil:
+  if self.view.currentAccount.account != nil:
     self.view.setLastLoginResponse(response.event)
     if ?.response.event.error == "":
-      self.status.events.emit("login", AccountArgs(account: self.status.accounts.currentLoginAccount))
+      self.status.events.emit("login", AccountArgs(account: self.view.currentAccount.account.toAccount))
 
 method onSignal(self: LoginController, data: Signal) =
   if data.signalType == SignalType.NodeLogin:

--- a/src/app/onboarding/core.nim
+++ b/src/app/onboarding/core.nim
@@ -31,10 +31,10 @@ proc init*(self: OnboardingController) =
 
 proc handleNodeLogin(self: OnboardingController, data: Signal) =
   let response = NodeSignal(data)
-  if self.status.accounts.currentOnboardingAccount != nil:
+  if self.view.currentAccount.account != nil:
     self.view.setLastLoginResponse(response.event)
     if ?.response.event.error == "":
-      self.status.events.emit("login", AccountArgs(account: self.status.accounts.currentOnboardingAccount))
+      self.status.events.emit("login", AccountArgs(account: self.view.currentAccount.account.toAccount))
 
 method onSignal(self: OnboardingController, data: Signal) =
   if data.signalType == SignalType.NodeLogin:

--- a/src/status/accounts.nim
+++ b/src/status/accounts.nim
@@ -6,13 +6,9 @@ type
   AccountModel* = ref object
     generatedAddresses*: seq[GeneratedAccount]
     nodeAccounts*: seq[NodeAccount]
-    currentLoginAccount*: Account
-    currentOnboardingAccount*: Account
 
 proc newAccountModel*(): AccountModel =
   result = AccountModel()
-  result.currentLoginAccount = nil
-  result.currentOnboardingAccount = nil
 
 proc generateAddresses*(self: AccountModel): seq[GeneratedAccount] =
   var accounts = status_accounts.generateAddresses()
@@ -24,17 +20,14 @@ proc generateAddresses*(self: AccountModel): seq[GeneratedAccount] =
 
 proc login*(self: AccountModel, selectedAccountIndex: int, password: string): NodeAccount =
   let currentNodeAccount = self.nodeAccounts[selectedAccountIndex]
-  self.currentLoginAccount = currentNodeAccount.toAccount
   result = status_accounts.login(currentNodeAccount, password)
 
 proc storeAccountAndLogin*(self: AccountModel, selectedAccountIndex: int, password: string): Account =
   let generatedAccount: GeneratedAccount = self.generatedAddresses[selectedAccountIndex]
   result = status_accounts.setupAccount(generatedAccount, password)
-  self.currentOnboardingAccount = generatedAccount.toAccount
 
 proc storeDerivedAndLogin*(self: AccountModel, importedAccount: GeneratedAccount, password: string): Account =
   result = status_accounts.setupAccount(importedAccount, password)
-  self.currentOnboardingAccount = importedAccount.toAccount
 
 proc importMnemonic*(self: AccountModel, mnemonic: string): GeneratedAccount =
   let importedAccount = status_accounts.multiAccountImportMnemonic(mnemonic)

--- a/ui/onboarding/ExistingKey.qml
+++ b/ui/onboarding/ExistingKey.qml
@@ -77,15 +77,15 @@ SwipeView {
             anchors.topMargin: 30
             Column {
                 Image {
-                  source: onboardingModel.importedAccount.identicon
+                  source: onboardingModel.currentAccount.identicon
                 }
             }
             Column {
                 Text {
-                  text: onboardingModel.importedAccount.username
+                  text: onboardingModel.currentAccount.username
                 }
                 Text {
-                  text: onboardingModel.importedAccount.address
+                  text: onboardingModel.currentAccount.address
                   width: 160
                   elide: Text.ElideMiddle
                 }
@@ -141,15 +141,15 @@ SwipeView {
             anchors.topMargin: 30
             Column {
                 Image {
-                  source: onboardingModel.importedAccount.identicon
+                  source: onboardingModel.currentAccount.identicon
                 }
             }
             Column {
                 Text {
-                  text: onboardingModel.importedAccount.username
+                  text: onboardingModel.currentAccount.username
                 }
                 Text {
-                  text: onboardingModel.importedAccount.address
+                  text: onboardingModel.currentAccount.address
                   width: 160
                   elide: Text.ElideMiddle
                 }

--- a/ui/onboarding/GenKey.qml
+++ b/ui/onboarding/GenKey.qml
@@ -111,6 +111,7 @@ SwipeView {
                     label: "Select"
 
                     onClicked: {
+                        onboardingModel.setCurrentAccount(wizardStep1.selectedIndex)
                         swipeView.incrementCurrentIndex()
                     }
                 }
@@ -124,11 +125,34 @@ SwipeView {
         property Item txtPassword: txtPassword
 
         Text {
+            id: step2Title
             text: "Enter password"
             font.pointSize: 36
             anchors.top: parent.top
             anchors.topMargin: 20
             anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: step2Title.bottom
+            anchors.topMargin: 30
+            Column {
+                Image {
+                  source: onboardingModel.currentAccount.identicon
+                }
+            }
+            Column {
+                Text {
+                  text: onboardingModel.currentAccount.username
+                }
+                Text {
+                  text: onboardingModel.currentAccount.address
+                  width: 160
+                  elide: Text.ElideMiddle
+                }
+
+            }
         }
 
         Input {
@@ -165,11 +189,34 @@ SwipeView {
         property Item txtPassword: txtConfirmPassword
 
         Text {
+            id: step3Title
             text: "Confirm password"
             font.pointSize: 36
             anchors.top: parent.top
             anchors.topMargin: 20
             anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: step3Title.bottom
+            anchors.topMargin: 30
+            Column {
+                Image {
+                  source: onboardingModel.currentAccount.identicon
+                }
+            }
+            Column {
+                Text {
+                  text: onboardingModel.currentAccount.username
+                }
+                Text {
+                  text: onboardingModel.currentAccount.address
+                  width: 160
+                  elide: Text.ElideMiddle
+                }
+
+            }
         }
 
         Input {

--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -66,11 +66,6 @@ SwipeView {
                         Text {
                             text: username
                         }
-                        Text {
-                            text: key
-                            width: 160
-                            elide: Text.ElideMiddle
-                        }
                     }
                 }
             }
@@ -117,6 +112,7 @@ SwipeView {
                 label: "Select"
 
                 onClicked: {
+                    loginModel.setCurrentAccount(wizardStep1.selectedIndex)
                     swipeView.incrementCurrentIndex()
                 }
             }
@@ -128,11 +124,28 @@ SwipeView {
         property Item txtPassword: txtPassword
 
         Text {
+            id: step2Title
             text: "Enter password"
             font.pointSize: 36
             anchors.top: parent.top
             anchors.topMargin: 20
             anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: step2Title.bottom
+            anchors.topMargin: 30
+            Column {
+                Image {
+                  source: loginModel.currentAccount.identicon
+                }
+            }
+            Column {
+                Text {
+                  text: loginModel.currentAccount.username
+                }
+            }
         }
 
         Input {


### PR DESCRIPTION
- fix: Change displayed login key to whisper public key (starts with 0x04)
- fix: remove key displayed on login accounts as this value is not passed to use from status-go's openAccounts
- feat: add selected account view when entering password for login and generating an account (same UI as importing a key)