### PR TITLE
build system refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,34 +8,15 @@ Experiments calling status-go from nim, inspired in [nim-stratus](https://github
 
 * QT
 
-install QT https://www.qt.io/download-qt-installer
-and add it to the PATH
-```
-# Linux
-export PATH=$PATH:/path/to/Qt/5.14.2/gcc_64/bin
-
-# macos
-export PATH=$PATH:/path/to/Qt/5.14.2/clang_64/bin
-```
-
-Linux users can also install Qt through the system's package manager:
+Linux users should install Qt through the system's package manager:
 
 ```
 # Debian/Ubuntu:
 sudo apt install qtbase5-dev qtdeclarative5-dev qml-module-qt-labs-platform
 ```
 
-* go - (used to build status-go)
-
-```
-# linux
-<TODO>
-
-# macos
-brew install go
-```
-
-### 1. Install QT, and add it to the PATH
+If that's not possible, manually install QT from https://www.qt.io/download-qt-installer
+and add it to the PATH
 
 ```
 # Linux
@@ -45,24 +26,43 @@ export PATH=$PATH:/path/to/Qt/5.14.2/gcc_64/bin
 export PATH=$PATH:/path/to/Qt/5.14.2/clang_64/bin
 ```
 
+* Go - (used to build status-go)
+
+```
+# Linux
+<TODO>
+
+# macOS
+brew install go
+```
+
+### 1. Install QT, and add it to the PATH
+
+```
+# Linux users should use their distro's package manager, but in case they do a manual install:
+export PATH=$PATH:/path/to/Qt/5.14.2/gcc_64/bin
+
+# macOS:
+export PATH=$PATH:/path/to/Qt/5.14.2/clang_64/bin
+```
+
 ### 2. Clone the repo and build `nim-status-client`
 ```
-git clone https://github.com/status-im/nim-status-client/ --recurse-submodules
+git clone https://github.com/status-im/nim-status-client
+cd nim-status-client
+make update
 make
 ```
 
-if you previously cloned the repo without the `--recurse-submodule` options, then do
+For more output use `make V=1 ...`.
 
-```
-git submodule update --init --recursive
-make
-```
+Use 4 CPU cores with `make -j4 ...`.
 
-for more output use `make V=1`
+Users with manually installed Qt5 packages need to run `make QTDIR="/path/to/Qt" ...`
 
-**Trouble Shooting**:
+**Troubleshooting**:
 
-If the `make` command fails due to already installed homebrew packages, such as:
+If the `make` command fails due to already installed Homebrew packages, such as:
 
 ```
 Error: protobuf 3.11.4 is already installed
@@ -74,15 +74,12 @@ make: *** [vendor/status-go/build/bin/libstatus.a] Error 2
 This can be fixed by uninstalling the package e.g. `brew uninstall protobuf` followed by rerunning `make`.
 
 
-### 3. Setup Library Path
-```
-export LD_LIBRARY_PATH=vendor/DOtherSide/build/lib/
-```
-
-### 4. Run the app
+### 3. Run the app
 
 ```
-./bin/nim_status_client
+make run
+# or
+LD_LIBRARY_PATH=vendor/DOtherSide/lib ./bin/nim_status_client
 ```
 
 ## Development
@@ -92,7 +89,7 @@ If making changes in the nim code `src/` then doing `make` again is needed (it's
 
 ## Cold Reload
 
-### 5. "Cold" reload using VSCode
+### "Cold" reload using VSCode
 
 We can setup a "cold" reload, whereby the app will be rebuilt and restarted when changes in the source are saved. This will not save state, as the app will be restarted, but it will save us some time from manually restarting the app. We can handily force an app rebuild/relaunch with the shortcut `Cmd+Shift+b` (execute the default build task, which we'll setup below).
 

--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,51 @@
+when defined(macosx):
+  import algorithm, strutils
+
+if defined(release):
+  switch("nimcache", "nimcache/release/$projectName")
+else:
+  switch("nimcache", "nimcache/debug/$projectName")
+
+proc linkLib(name: string): string =
+  var resLib = name
+
+  when defined(macosx):
+    # In macOS Catalina, unversioned libraries may be broken stubs, so we need to
+    # find a versioned one: https://github.com/status-im/nim-status-client/pull/209
+    var matches: seq[string]
+    for path in listFiles("/usr/lib"):
+      # /usr/lib/libcrypto.0.9.8.dylib
+      let file = path[9..^1]
+      # libcrypto.0.9.8.dylib
+      if file.startsWith("lib" & name) and file != "lib" & name & ".dylib":
+        matches.add(path)
+    matches.sort(order = SortOrder.Descending)
+    if matches.len > 0:
+      resLib = matches[0]
+      # Passing "/usr/lib/libcrypto.44.dylib" directly to the linker works for
+      # dynamic linking.
+      return resLib
+
+  return "-l" & resLib
+
+--threads:on
+--opt:speed # -O3
+--debugger:native # passes "-g" to the C compiler
+--dynliboverrideall # don't use dlopen()
+--define:ssl # needed by the stdlib to enable SSL procedures
+
+if defined(macosx):
+  --tlsEmulation:off
+  # DYLD_LIBRARY_PATH doesn't seem to work with Qt5
+  switch("passL", "-rpath" & " " & getEnv("QT5_LIBDIR"))
+  switch("passL", "-lstdc++")
+  # dynamically link these libs, since we're opting out of dlopen()
+  switch("passL", linkLib("crypto"))
+  switch("passL", linkLib("ssl"))
+  # https://code.videolan.org/videolan/VLCKit/-/issues/232
+  switch("passL", "-Wl,-no_compact_unwind")
+else:
+  switch("passL", linkLib("crypto") & " " & linkLib("ssl")) # dynamically link these libs, since we're opting out of dlopen()
+  switch("passL", "-Wl,-as-needed") # don't link libraries we're not actually using
+
+--define:chronicles_line_numbers # useful when debugging

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,3 @@
+# we need to link C++ libraries
+gcc.linkerexe="g++"
+

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -65,7 +65,7 @@ proc mainProc() =
 
   login.init(nodeAccounts)
   engine.setRootContextProperty("loginModel", login.variant)
-  
+
   onboarding.init()
   engine.setRootContextProperty("onboardingModel", onboarding.variant)
 
@@ -76,7 +76,7 @@ proc mainProc() =
   signalController.addSubscriber(SignalType.DiscoverySummary, chat)
   signalController.addSubscriber(SignalType.NodeLogin, login)
   signalController.addSubscriber(SignalType.NodeLogin, onboarding)
-  
+
   engine.setRootContextProperty("signals", signalController.variant)
 
   engine.load("../ui/main.qml")

--- a/src/nim_status_client.nim.cfg
+++ b/src/nim_status_client.nim.cfg
@@ -1,9 +1,0 @@
---threads:on
---tlsEmulation:off 
-
-@if release:
-  nimcache = "nimcache/release/$projectName"
-@else:
-  nimcache = "nimcache/debug/$projectName"
-@end
-


### PR DESCRIPTION
This is a redo of PR #113. The important difference is that `--tlsEmulation:off` is set for macOS (it's on by default for macOS) since with the emulation turned on the app wasn't working.

---

- unify the "build-..." targets
- enable a debug build by default, to simplify development
- bump vendor/DOtherSide
- avoid DOtherSide checks for docs/tests-specific tools like Doxygen
- switch to an in-place build for DOtherSide
- silence the DOtherSide build when V=0, make it more verbose with V=1
- don't delete checked out submodules in the "clean" target
- update build instructions in the README
- centralise Nim compiler options in a top-level "config.nims" (except
  `-d:debug` which needs to be on the command line)