### PR TITLE
ui: fine-tune rounded icon border

### DIFF
--- a/ui/shared/RoundImage.qml
+++ b/ui/shared/RoundImage.qml
@@ -9,7 +9,7 @@ Rectangle {
     color: Theme.white
     radius: 50
     border.width: 1
-    border.color: Theme.darkGrey
+    border.color: "#10000000"
 
     Image {
         width: parent.width


### PR DESCRIPTION
The border color of `RoundedColor` is way darker than channel and chat icons in
other places of the application.

This commit aligns it so it's the same everywhere