### PR TITLE
Add form validation

### DIFF
--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -7,8 +7,24 @@ import "../../Profile/Sections/Contacts/"
 import "./"
 
 ModalPopup {
-    function doJoin(){
+    property string validationError: ""
+
+    function validate() {
+        // TODO change this when we support ENS names
+        if (!Utils.isChatKey(chatKey.text)) {
+            validationError = "This needs to be a valid chat key"
+        } else {
+            validationError = ""
+        }
+        return validationError === ""
+    }
+
+    function doJoin() {
         if (chatKey.text !== "") {
+            if (!validate()) {
+                return
+            }
+
             chatsModel.joinChat(chatKey.text, Constants.chatTypeOneToOne);
         } else if (contactListView.selectedContact.checked) {
             chatsModel.joinChat(contactListView.selectedContact.parent.address, Constants.chatTypeOneToOne);
@@ -24,7 +40,9 @@ ModalPopup {
     onOpened: {
         chatKey.text = "";
         chatKey.forceActiveFocus(Qt.MouseFocusReason)
-        contactListView.selectedContact.checked = false
+        if (contactListView.selectedContact) {
+            contactListView.selectedContact.checked = false
+        }
     }
 
     Input {
@@ -32,6 +50,10 @@ ModalPopup {
         placeholderText: qsTr("Enter ENS username or chat key")
         Keys.onEnterPressed: doJoin()
         Keys.onReturnPressed: doJoin()
+        validationError: popup.validationError
+        textField.onEditingFinished: {
+            validate()
+        }
     }
 
     ContactList {

--- a/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
@@ -11,7 +11,7 @@ ModalPopup {
     id: popup
     // TODO add icon when we have that feature
     title: qsTr("Status account settings")
-    height: 630
+    height: 635
 
     property int marginBetweenInputs: 35
     property string selectedColor: currentAccount.iconColor
@@ -91,7 +91,6 @@ ModalPopup {
         anchors.fill: parent
         StyledButton {
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
             anchors.right: saveBtn.left
             anchors.rightMargin: Theme.padding
             label: qsTr("Delete account")
@@ -133,7 +132,6 @@ ModalPopup {
         StyledButton {
             id: saveBtn
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
             anchors.right: parent.right
             anchors.rightMargin: Theme.padding
             label: qsTr("Save changes")

--- a/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
@@ -15,6 +15,17 @@ ModalPopup {
 
     property int marginBetweenInputs: 35
     property string selectedColor: currentAccount.iconColor
+    property string accountNameValidationError: ""
+
+    function validate() {
+        if (accountNameInput.text === "") {
+            accountNameValidationError = qsTr("You need to enter an account name")
+        } else {
+            accountNameValidationError = ""
+        }
+
+        return accountNameValidationError === ""
+    }
 
     onOpened: {
         accountNameInput.forceActiveFocus(Qt.MouseFocusReason)
@@ -25,6 +36,7 @@ ModalPopup {
         placeholderText: qsTr("Enter an account name...")
         label: qsTr("Account name")
         text: currentAccount.name
+        validationError: popup.accountNameValidationError
     }
 
     Select {
@@ -146,9 +158,8 @@ ModalPopup {
             }
 
             onClicked : {
-                if (accountNameInput.text === "") {
-                    changeError.text = qsTr("Account name cannot be empty")
-                    changeError.open()
+                if (!validate()) {
+                    return
                 }
 
                 const error = walletModel.changeAccountSettings(currentAccount.address, accountNameInput.text, selectedColor);

--- a/ui/app/AppLayouts/Wallet/TokenSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/TokenSettingsModal.qml
@@ -18,7 +18,6 @@ ModalPopup {
         anchors.rightMargin: Theme.padding
         label: qsTr("Add custom token")
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
         onClicked: {
             popup.close()
             addCustomTokenModal.open()

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
@@ -9,6 +9,35 @@ ModalPopup {
 
     property int marginBetweenInputs: 38
     property string selectedColor: Constants.accountColors[0]
+    property string passwordValidationError: ""
+    property string privateKeyValidationError: ""
+    property string accountNameValidationError: ""
+
+    function validate() {
+        if (passwordInput.text === "") {
+            passwordValidationError = qsTr("You need to enter a password")
+        } else if (passwordInput.text.length < 4) {
+            passwordValidationError = qsTr("Password needs to be 4 characters or more")
+        } else {
+            passwordValidationError = ""
+        }
+
+        if (accountNameInput.text === "") {
+            accountNameValidationError = qsTr("You need to enter an account name")
+        } else {
+            accountNameValidationError = ""
+        }
+
+        if (accountPKeyInput.text === "") {
+            privateKeyValidationError = qsTr("You need to enter a private key")
+        } else if (!Utils.isPrivateKey(accountPKeyInput.text)) {
+            privateKeyValidationError = qsTr("Enter a valid private key (64 characters hexadecimal string)")
+        } else {
+            privateKeyValidationError = ""
+        }
+
+        return passwordValidationError === "" && privateKeyValidationError === "" && accountNameValidationError === ""
+    }
 
     onOpened: {
         passwordInput.text = ""
@@ -20,6 +49,7 @@ ModalPopup {
         placeholderText: qsTr("Enter your password…")
         label: qsTr("Password")
         textField.echoMode: TextInput.Password
+        validationError: popup.passwordValidationError
     }
 
 
@@ -30,6 +60,7 @@ ModalPopup {
         placeholderText: qsTr("Paste the contents of your private key")
         label: qsTr("Private key")
         customHeight: 88
+        validationError: popup.privateKeyValidationError
     }
 
     Input {
@@ -38,6 +69,7 @@ ModalPopup {
         anchors.topMargin: marginBetweenInputs
         placeholderText: qsTr("Enter an account name...")
         label: qsTr("Account name")
+        validationError: popup.accountNameValidationError
     }
 
     Select {
@@ -60,16 +92,16 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
         label: qsTr("Add account >")
 
-        disabled: passwordInput.text === "" || accountNameInput.text === "" || accountPKeyInput.textAreaText === ""
+        disabled: passwordInput.text === "" || accountNameInput.text === "" || accountPKeyInput.text === ""
 
         onClicked : {
-            // TODO add message to show validation errors
-            if (passwordInput.text === "" || accountNameInput.text === "" || accountPKeyInput.textAreaText === "") return;
+            if (!validate()) {
+                return
+            }
 
             walletModel.addAccountsFromPrivateKey(accountPKeyInput.text, passwordInput.text, accountNameInput.text, selectedColor)
             // TODO manage errors adding account

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
@@ -8,6 +8,35 @@ ModalPopup {
 
     property int marginBetweenInputs: 38
     property string selectedColor: Constants.accountColors[0]
+    property string passwordValidationError: ""
+    property string seedValidationError: ""
+    property string accountNameValidationError: ""
+
+    function validate() {
+        if (passwordInput.text === "") {
+            passwordValidationError = qsTr("You need to enter a password")
+        } else if (passwordInput.text.length < 4) {
+            passwordValidationError = qsTr("Password needs to be 4 characters or more")
+        } else {
+            passwordValidationError = ""
+        }
+
+        if (accountNameInput.text === "") {
+            accountNameValidationError = qsTr("You need to enter an account name")
+        } else {
+            accountNameValidationError = ""
+        }
+
+        if (accountSeedInput.text === "") {
+            seedValidationError = qsTr("You need to enter a seed phrase")
+        } else if (!Utils.isMnemonic(accountSeedInput.text)) {
+            seedValidationError = qsTr("Enter a valid mnemonic")
+        } else {
+            seedValidationError = ""
+        }
+
+        return passwordValidationError === "" && seedValidationError === "" && accountNameValidationError === ""
+    }
 
     onOpened: {
         passwordInput.text = ""
@@ -21,6 +50,7 @@ ModalPopup {
         placeholderText: qsTr("Enter your password…")
         label: qsTr("Password")
         textField.echoMode: TextInput.Password
+        validationError: popup.passwordValidationError
     }
 
 
@@ -31,6 +61,7 @@ ModalPopup {
         placeholderText: qsTr("Enter your seed phrase, separate words with commas or spaces...")
         label: qsTr("Seed phrase")
         customHeight: 88
+        validationError: popup.seedValidationError
     }
 
     Input {
@@ -39,6 +70,7 @@ ModalPopup {
         anchors.topMargin: marginBetweenInputs
         placeholderText: qsTr("Enter an account name...")
         label: qsTr("Account name")
+        validationError: popup.accountNameValidationError
     }
 
     Select {
@@ -61,16 +93,16 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
-        label: "Add account 00>"
+        label: "Add account >"
 
         disabled: passwordInput.text === "" || accountNameInput.text === "" || accountSeedInput.text === ""
 
         onClicked : {
-            // TODO add message to show validation errors
-            if (passwordInput.text === "" || accountNameInput.text === "" || accountSeedInput.text === "") return;
+            if (!validate()) {
+                return
+            }
 
             walletModel.addAccountsFromSeed(accountSeedInput.text, passwordInput.text, accountNameInput.text, selectedColor)
             // TODO manage errors adding account

--- a/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
@@ -8,6 +8,26 @@ ModalPopup {
 
     property int marginBetweenInputs: 38
     property string selectedColor: Constants.accountColors[0]
+    property string addressError: ""
+    property string accountNameValidationError: ""
+
+    function validate() {
+        if (addressInput.text === "") {
+            addressError = qsTr("You need to enter an address")
+        } else if (!Utils.isAddress(addressInput.text)) {
+            addressError = qsTr("This needs to be a valid address (starting with 0x)")
+        } else {
+            addressError = ""
+        }
+
+        if (accountNameInput.text === "") {
+            accountNameValidationError = qsTr("You need to enter an account name")
+        } else {
+            accountNameValidationError = ""
+        }
+
+        return addressError === "" && accountNameValidationError === ""
+    }
 
     onOpened: {
         addressInput.text = "";
@@ -19,6 +39,7 @@ ModalPopup {
         // TODO add QR code reader for the address
         placeholderText: qsTr("Enter address...")
         label: qsTr("Account address")
+        validationError: popup.addressError
     }
 
     Input {
@@ -27,6 +48,7 @@ ModalPopup {
         anchors.topMargin: marginBetweenInputs
         placeholderText: qsTr("Enter an account name...")
         label: qsTr("Account name")
+        validationError: popup.accountNameValidationError
     }
 
     Select {
@@ -49,7 +71,6 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
         label: "Add account >"
@@ -57,8 +78,10 @@ ModalPopup {
         disabled: addressInput.text === "" || accountNameInput.text === ""
 
         onClicked : {
-            // TODO add message to show validation errors
-            if (addressInput.text === "" || accountNameInput.text === "") return;
+            if (!validate()) {
+                return
+            }
+
             walletModel.addWatchOnlyAccount(addressInput.text, accountNameInput.text, selectedColor);
             // TODO manage errors adding account
             popup.close();

--- a/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
@@ -8,6 +8,26 @@ ModalPopup {
 
     property int marginBetweenInputs: 38
     property string selectedColor: Constants.accountColors[0]
+    property string passwordValidationError: ""
+    property string accountNameValidationError: ""
+
+    function validate() {
+        if (passwordInput.text === "") {
+            passwordValidationError = qsTr("You need to enter a password")
+        } else if (passwordInput.text.length < 4) {
+            passwordValidationError = qsTr("Password needs to be 4 characters or more")
+        } else {
+            passwordValidationError = ""
+        }
+
+        if (accountNameInput.text === "") {
+            accountNameValidationError = qsTr("You need to enter an account name")
+        } else {
+            accountNameValidationError = ""
+        }
+
+        return passwordValidationError === "" && accountNameValidationError === ""
+    }
 
     onOpened: {
         passwordInput.text = "";
@@ -19,6 +39,7 @@ ModalPopup {
         placeholderText: qsTr("Enter your password…")
         label: qsTr("Password")
         textField.echoMode: TextInput.Password
+        validationError: popup.passwordValidationError
     }
 
     Input {
@@ -27,6 +48,7 @@ ModalPopup {
         anchors.topMargin: marginBetweenInputs
         placeholderText: qsTr("Enter an account name...")
         label: qsTr("Account name")
+        validationError: popup.accountNameValidationError
     }
 
     Select {
@@ -49,7 +71,6 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
         anchors.right: parent.right
         anchors.rightMargin: Theme.padding
         label: "Add account >"
@@ -57,8 +78,10 @@ ModalPopup {
         disabled: passwordInput.text === "" || accountNameInput.text === ""
 
         onClicked : {
-            // TODO add message to show validation errors
-            if (passwordInput.text === "" || accountNameInput.text === "") return;
+            if (!validate()) {
+                return
+            }
+
             walletModel.generateNewAccount(passwordInput.text, accountNameInput.text, selectedColor);
             // TODO manage errors adding account
             popup.close();

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -4,7 +4,7 @@ import QtQuick 2.13
 
 QtObject {
     function isHex(value) {
-        return /^[0-9a-f]*$/i.test(value)
+        return /^(-0x|0x)?[0-9a-f]*$/i.test(value)
     }
 
     function startsWith0x(value) {
@@ -13,5 +13,14 @@ QtObject {
 
     function isChatKey(value) {
         return startsWith0x(value) && isHex(value) && value.length === 132
+    }
+
+    function isAddress(value) {
+        return startsWith0x(value) && isHex(value) && value.length === 42
+    }
+
+    function isPrivateKey(value) {
+        return isHex(value) && ((startsWith0x(value) && value.length === 66) ||
+                                (!startsWith0x(value) && value.length === 64))
     }
 }

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -23,4 +23,9 @@ QtObject {
         return isHex(value) && ((startsWith0x(value) && value.length === 66) ||
                                 (!startsWith0x(value) && value.length === 64))
     }
+
+    function isMnemonic(value) {
+        // Do we support other length than 12?
+        return value.split(/\s|,/).length === 12
+    }
 }

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -1,0 +1,17 @@
+pragma Singleton
+
+import QtQuick 2.13
+
+QtObject {
+    function isHex(value) {
+        return /^[0-9a-f]*$/i.test(value)
+    }
+
+    function startsWith0x(value) {
+        return value.startsWith('0x')
+    }
+
+    function isChatKey(value) {
+        return startsWith0x(value) && isHex(value) && value.length === 132
+    }
+}

--- a/ui/imports/qmldir
+++ b/ui/imports/qmldir
@@ -1,3 +1,5 @@
 module Theme
 singleton Theme 1.0 ./Theme.qml
 singleton Constants 1.0 ./Constants.qml
+singleton Utils 1.0 ./Utils.qml
+

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -161,6 +161,7 @@ DISTFILES += \
     app/img/wallet.svg \
     app/img/walletActive.svg \
     app/qmldir \
+    imports/Utils.qml \
     imports/qmldir \
     onboarding/CreatePasswordModal.qml \
     onboarding/EnterSeedPhraseModal.qml \

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -6,6 +6,7 @@ Item {
     property alias textField: inputValue
     property string placeholderText: "My placeholder"
     property alias text: inputValue.text
+    property string validationError: ""
     property string label: ""
     //    property string label: "My Label"
     readonly property bool hasLabel: label !== ""
@@ -24,7 +25,7 @@ Item {
     property int fontPixelSize: 15
 
     id: inputBox
-    height: inputRectangle.height + (hasLabel ? inputLabel.height + labelMargin : 0)
+    height: inputRectangle.height + (hasLabel ? inputLabel.height + labelMargin : 0) + (!!validationError ? validationErrorText.height : 0)
     anchors.right: parent.right
     anchors.left: parent.left
 
@@ -49,6 +50,9 @@ Item {
         anchors.topMargin: inputBox.hasLabel ? inputBox.labelMargin : 0
         anchors.right: parent.right
         anchors.left: parent.left
+        border.width: !!validationError ? 1 : 0
+        border.color: Theme.red
+
         StyledTextField {
             id: inputValue
             visible: !inputBox.isTextArea && !inputBox.isSelect
@@ -81,10 +85,23 @@ Item {
             source: inputBox.icon
         }
     }
+
+    TextEdit {
+        visible: !!validationError
+        id: validationErrorText
+        text: validationError
+        anchors.top: inputRectangle.bottom
+        anchors.topMargin: 1
+        selectByMouse: true
+        readOnly: true
+        font.pixelSize: 12
+        color: Theme.red
+
+    }
 }
 
 /*##^##
 Designer {
-    D{i:0;formeditorColor:"#ffffff";formeditorZoom:1.25}
+    D{i:0;formeditorColor:"#c0c0c0";formeditorZoom:1.25}
 }
 ##^##*/

--- a/ui/shared/StyledTextArea.qml
+++ b/ui/shared/StyledTextArea.qml
@@ -8,6 +8,7 @@ Item {
     property alias textField: textArea
     property string placeholderText: "My placeholder"
     property alias text: textArea.text
+    property string validationError: ""
     //    property string label: "My Label"
     property string label: ""
     readonly property bool hasLabel: label !== ""
@@ -19,7 +20,7 @@ Item {
     property int customHeight: 44
 
     id: inputBox
-    height: inputRectangle.height + (hasLabel ? inputLabel.height + labelMargin : 0)
+    height: inputRectangle.height + (hasLabel ? inputLabel.height + labelMargin : 0) + (!!validationError ? validationErrorText.height : 0)
     anchors.right: parent.right
     anchors.left: parent.left
 
@@ -44,6 +45,8 @@ Item {
         anchors.topMargin: inputBox.hasLabel ? inputBox.labelMargin : 0
         anchors.right: parent.right
         anchors.left: parent.left
+        border.width: !!validationError ? 1 : 0
+        border.color: Theme.red
 
         TextArea {
             id: textArea
@@ -58,14 +61,27 @@ Item {
             anchors.fill: parent
             font.family: Theme.fontRegular.name
         }
+
+        MouseArea {
+            id: mouseArea
+            anchors.fill: parent
+            onClicked: {
+                textArea.forceActiveFocus(Qt.MouseFocusReason)
+            }
+        }
     }
 
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        onClicked: {
-            textArea.forceActiveFocus(Qt.MouseFocusReason)
-        }
+    TextEdit {
+        visible: !!validationError
+        id: validationErrorText
+        text: validationError
+        anchors.top: inputRectangle.bottom
+        anchors.topMargin: 1
+        selectByMouse: true
+        readOnly: true
+        font.pixelSize: 12
+        color: Theme.red
+
     }
 }
 


### PR DESCRIPTION
Adds the `validationError` prop on Input and StyledTextArea to show a message on the field when there is an error

Add validation to add private chat and the wallet forms.

![image](https://user-images.githubusercontent.com/11926403/85324371-b6e8e880-b497-11ea-86c5-7962dfd5deba.png)

Known issue: if you have a validation then fix it and press enter, the error stays even though it was removed from memory. The problem is that QT "freezes" when we call the Nim function so it doesn't re-render. We have that problem at a couple of places where we'd need loading states.