### PR TITLE
chore: up import version and fix SplitViews

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -15,7 +15,6 @@ ScrollView {
     property real scrollY: chatLogView.visibleArea.yPosition * chatLogView.contentHeight
 
     contentItem: chatLogView
-    anchors.fill: parent
     Layout.fillWidth: true
     Layout.fillHeight: true
 

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -1,13 +1,18 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
+import Qt.labs.settings 1.0
 import "../../../imports"
 import "../../../shared"
 import "."
 
 SplitView {
-    id: chatView
+    property var appSettings
 
+    id: chatView
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.chatSplitView)
+    Component.onDestruction: appSettings.chatSplitView = this.saveState()
 
     ContactsColumn {
         id: contactsColumn

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -1,26 +1,19 @@
 import QtQuick 2.13
-//TODO: update to import QtQuick.Controls 2.13
-import QtQuick.Controls 1.3
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.13
+import QtQuick.Controls 2.13
 import "../../../imports"
+import "../../../shared"
 import "."
 
 SplitView {
     id: chatView
-    x: 0
-    y: 0
-    Layout.fillHeight: true
-    Layout.fillWidth: true
 
-    handleDelegate: Rectangle {
-        implicitWidth: 1
-        implicitHeight: 4
-        color: Theme.grey
-    }
+    handle: SplitViewHandle {}
 
     ContactsColumn {
         id: contactsColumn
+        SplitView.preferredWidth: Theme.leftTabPrefferedSize
+        SplitView.minimumWidth: Theme.leftTabMinimumWidth
+        SplitView.maximumWidth: Theme.leftTabMaximumWidth
     }
 
     ChatColumn {
@@ -31,6 +24,6 @@ SplitView {
 
 /*##^##
 Designer {
-    D{i:0;formeditorZoom:0.5;height:770;width:1152}
+    D{i:0;formeditorColor:"#ffffff";formeditorZoom:1.25;height:770;width:1152}
 }
 ##^##*/

--- a/ui/app/AppLayouts/Chat/ContactsColumn.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn.qml
@@ -12,8 +12,6 @@ Item {
     property alias searchStr: searchBox.text
 
     id: contactsColumn
-    width: 300
-    Layout.minimumWidth: 200
     Layout.fillHeight: true
 
     StyledText {

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -15,11 +15,8 @@ Rectangle {
     id: wrapper
     color: ListView.isCurrentItem ? Theme.lightBlue : Theme.transparent
     anchors.right: parent.right
-    anchors.rightMargin: Theme.padding
     anchors.top: applicationWindow.top
-    anchors.topMargin: 0
     anchors.left: parent.left
-    anchors.leftMargin: Theme.padding
     radius: 8
     // Hide the box if it is filtered out
     property bool isVisible: searchStr == "" || name.includes(searchStr)

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
@@ -14,7 +14,12 @@ Item {
 
     ListView {
         id: chatGroupsListView
-        anchors.fill: parent
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.left: parent.left
+        anchors.rightMargin: Theme.padding
+        anchors.leftMargin: Theme.padding
         model: chatsModel.chats
         delegate: Channel {
             name: model.name

--- a/ui/app/AppLayouts/Node/NodeLayout.qml
+++ b/ui/app/AppLayouts/Node/NodeLayout.qml
@@ -4,24 +4,15 @@ import QtQuick.Layouts 1.13
 import "../../../imports"
 import "../../../shared"
 
-SplitView {
+Item {
     id: nodeView
-    x: 0
-    y: 0
     Layout.fillHeight: true
     Layout.fillWidth: true
 
     ColumnLayout {
         id: rpcColumn
         spacing: 0
-//        anchors.left: contactsColumn.right
-        anchors.leftMargin: 0
-        anchors.right: parent.right
-        anchors.rightMargin: 0
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
-        anchors.top: parent.top
-        anchors.topMargin: 0
+        anchors.fill: parent
 
         ColumnLayout {
             id: messageContainer

--- a/ui/app/AppLayouts/Profile/LeftTab.qml
+++ b/ui/app/AppLayouts/Profile/LeftTab.qml
@@ -5,11 +5,9 @@ import "../../../shared"
 import "./LeftTab"
 
 ColumnLayout {
-    readonly property int w: 340
     property alias currentTab: profileMenu.profileCurrentIndex
 
     id: profileInfoContainer
-    width: w
     spacing: 0
     anchors.left: parent.left
     anchors.leftMargin: 0
@@ -17,13 +15,11 @@ ColumnLayout {
     anchors.topMargin: 0
     anchors.bottom: parent.bottom
     anchors.bottomMargin: 0
-    Layout.minimumWidth: 300
 
     RowLayout {
         id: profileHeader
         height: 240
         Layout.fillWidth: true
-        width: profileInfoContainer.w
 
         Profile {
             username: profileModel.profile.username
@@ -33,7 +29,6 @@ ColumnLayout {
     }
 
     RowLayout {
-        width: profileInfoContainer.w
         height: btnheight * 10
         Layout.fillHeight: true
         Layout.fillWidth: true

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -12,14 +12,13 @@ SplitView {
     Layout.fillHeight: true
     Layout.fillWidth: true
 
-    handle: Rectangle {
-        implicitWidth: 1
-        implicitHeight: 4
-        color: Theme.grey
-    }
+    handle: SplitViewHandle {}
 
     LeftTab {
         id: leftTab
+        SplitView.preferredWidth: Theme.leftTabPrefferedSize
+        SplitView.minimumWidth: Theme.leftTabMinimumWidth
+        SplitView.maximumWidth: Theme.leftTabMaximumWidth
     }
 
     StackLayout {

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -6,13 +6,16 @@ import "../../../shared"
 import "./Sections"
 
 SplitView {
+    property var appSettings
+
     id: profileView
-    x: 0
-    y: 0
     Layout.fillHeight: true
     Layout.fillWidth: true
 
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.profileSplitView)
+    Component.onDestruction: appSettings.profileSplitView = this.saveState()
 
     LeftTab {
         id: leftTab

--- a/ui/app/AppLayouts/Wallet/LeftTab.qml
+++ b/ui/app/AppLayouts/Wallet/LeftTab.qml
@@ -16,8 +16,6 @@ Item {
         walletModel.setCurrentAccountByIndex(newIndex)
     }
     id: walletInfoContainer
-    width: 340
-    Layout.minimumWidth: 300
 
     Rectangle {
         id: walletInfoHeader

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -1,7 +1,5 @@
 import QtQuick 2.13
-//TODO: update to import QtQuick.Controls 2.13
-import QtQuick.Controls 1.3
-import QtQuick.Controls 2.3
+import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../imports"
 import "../../../shared"
@@ -9,20 +7,16 @@ import "."
 
 SplitView {
     id: walletView
-    x: 0
-    y: 0
     Layout.fillHeight: true
     Layout.fillWidth: true
 
-    // handle for QtQuick.Controls 2.13
-    handleDelegate: Rectangle {
-        implicitWidth: 1
-        implicitHeight: 4
-        color: Theme.grey
-    }
+    handle: SplitViewHandle {}
 
     LeftTab {
         id: leftTab
+        SplitView.preferredWidth: Theme.leftTabPrefferedSize
+        SplitView.minimumWidth: Theme.leftTabMinimumWidth
+        SplitView.maximumWidth: Theme.leftTabMaximumWidth
     }
 
     Item {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -6,11 +6,16 @@ import "../../../shared"
 import "."
 
 SplitView {
+    property var appSettings
+
     id: walletView
     Layout.fillHeight: true
     Layout.fillWidth: true
 
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.walletSplitView)
+    Component.onDestruction: appSettings.walletSplitView = this.saveState()
 
     LeftTab {
         id: leftTab

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -6,6 +6,8 @@ import "../shared"
 import "./AppLayouts"
 
 RowLayout {
+    property var appSettings
+
     id: rowLayout
     Layout.fillHeight: true
     Layout.fillWidth: true
@@ -169,6 +171,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         WalletLayout {
@@ -176,6 +179,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         BrowserLayout {
@@ -190,6 +194,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         NodeLayout {

--- a/ui/imports/Theme.qml
+++ b/ui/imports/Theme.qml
@@ -26,4 +26,8 @@ QtObject {
     readonly property int padding: 16
     readonly property int smallPadding: 10
     readonly property int radius: 8
+
+    readonly property int leftTabPrefferedSize: 340
+    readonly property int leftTabMinimumWidth: 300
+    readonly property int leftTabMaximumWidth: 500
 }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -3,18 +3,35 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import Qt.labs.platform 1.1
 import QtQml.StateMachine 1.14 as DSM
+import Qt.labs.settings 1.0
+import QtQml 2.13
 import "./onboarding"
 import "./app"
 import "./imports"
 
 ApplicationWindow {
+    property alias appSettings: settings
+
     id: applicationWindow
     width: 1232
     height: 770
-    title: "Nim Status Client"
+    title: {
+        // Set application settings
+        Qt.application.name = qsTr("Nim Status Client")
+        Qt.application.organization = "Status"
+        Qt.application.domain = "status.im"
+        return Qt.application.name
+    }
     visible: true
 
     signal navigateTo(string path)
+
+    Settings {
+       id: settings
+       property var chatSplitView
+       property var walletSplitView
+       property var profileSplitView
+   }
 
     SystemTrayIcon {
         visible: true
@@ -138,7 +155,9 @@ ApplicationWindow {
 
     Component {
         id: app
-        AppMain {}
+        AppMain {
+            appSettings: applicationWindow.appSettings
+        }
     }
 
     Component {

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -212,6 +212,7 @@ DISTFILES += \
     shared/SearchBox.qml \
     shared/Select.qml \
     shared/Separator.qml \
+    shared/SplitViewHandle.qml \
     shared/StatusTabButton.qml \
     shared/StyledButton.qml \
     shared/RoundedIcon.qml \

--- a/ui/shared/SplitViewHandle.qml
+++ b/ui/shared/SplitViewHandle.qml
@@ -3,8 +3,7 @@ import QtQuick.Controls 2.13
 import "../imports"
 
 Rectangle {
-    // FIXME setting this 1 is prettier, but makes the handle complety unusable (too small to grab)
-    implicitWidth: 2
+    implicitWidth: 1.2
     color: SplitHandle.pressed ? Theme.darkGrey
                 : (SplitHandle.hovered ? Qt.darker(Theme.grey, 1.1) : Theme.grey)
 }

--- a/ui/shared/SplitViewHandle.qml
+++ b/ui/shared/SplitViewHandle.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import "../imports"
+
+Rectangle {
+    // FIXME setting this 1 is prettier, but makes the handle complety unusable (too small to grab)
+    implicitWidth: 2
+    color: SplitHandle.pressed ? Theme.darkGrey
+                : (SplitHandle.hovered ? Qt.darker(Theme.grey, 1.1) : Theme.grey)
+}

--- a/ui/shared/qmldir
+++ b/ui/shared/qmldir
@@ -14,3 +14,4 @@ StyledTextField 1.0 StyledTextField.qml
 StyledTextEdit 1.0 StyledTextEdit.qml
 Identicon 1.0 Identicon.qml
 RoundedImage 1.0 RoundedImage.qml
+SplitViewHandle 1.0 SplitViewHandle.qml


### PR DESCRIPTION
Ups the version of QtControls to 2.13. This means that SplitViews needed to be fixed/changed.

One big problem was  that the new handle property changed and now, if we put a width of `1` on the handle, it's not usable. It is too small to grasp.
That's why, for now, I put it as `2` px large. I tried using a MouseArea or even putting the rectangle inside an Item and the item being bigger, but if you put the `implicitWidth` bigger for the mouse area to be bigger, it creates a margin that I wasn't able to fix.

Anyway, I put the handle in it's own component, so it's easy to change and I also added a hover and on click effect to make it obvious that you can resize.