### PR TITLE
feat: enable saving app settings like the SplitView state

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -1,13 +1,18 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
+import Qt.labs.settings 1.0
 import "../../../imports"
 import "../../../shared"
 import "."
 
 SplitView {
-    id: chatView
+    property var appSettings
 
+    id: chatView
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.chatSplitView)
+    Component.onDestruction: appSettings.chatSplitView = this.saveState()
 
     ContactsColumn {
         id: contactsColumn

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -6,13 +6,16 @@ import "../../../shared"
 import "./Sections"
 
 SplitView {
+    property var appSettings
+
     id: profileView
-    x: 0
-    y: 0
     Layout.fillHeight: true
     Layout.fillWidth: true
 
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.profileSplitView)
+    Component.onDestruction: appSettings.profileSplitView = this.saveState()
 
     LeftTab {
         id: leftTab

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -6,11 +6,16 @@ import "../../../shared"
 import "."
 
 SplitView {
+    property var appSettings
+
     id: walletView
     Layout.fillHeight: true
     Layout.fillWidth: true
 
     handle: SplitViewHandle {}
+
+    Component.onCompleted: this.restoreState(appSettings.walletSplitView)
+    Component.onDestruction: appSettings.walletSplitView = this.saveState()
 
     LeftTab {
         id: leftTab

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -5,6 +5,8 @@ import "../imports"
 import "./AppLayouts"
 
 RowLayout {
+    property var appSettings
+
     id: rowLayout
     Layout.fillHeight: true
     Layout.fillWidth: true
@@ -158,6 +160,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         WalletLayout {
@@ -165,6 +168,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         BrowserLayout {
@@ -179,6 +183,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignTop
             Layout.fillHeight: true
+            appSettings: rowLayout.appSettings
         }
 
         NodeLayout {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -3,18 +3,35 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import Qt.labs.platform 1.1
 import QtQml.StateMachine 1.14 as DSM
+import Qt.labs.settings 1.0
+import QtQml 2.13
 import "./onboarding"
 import "./app"
 import "./imports"
 
 ApplicationWindow {
+    property alias appSettings: settings
+
     id: applicationWindow
     width: 1232
     height: 770
-    title: "Nim Status Client"
+    title: {
+        // Set application settings
+        Qt.application.name = qsTr("Nim Status Client")
+        Qt.application.organization = "Status"
+        Qt.application.domain = "status.im"
+        return Qt.application.name
+    }
     visible: true
 
     signal navigateTo(string path)
+
+    Settings {
+       id: settings
+       property var chatSplitView
+       property var walletSplitView
+       property var profileSplitView
+   }
 
     SystemTrayIcon {
         visible: true
@@ -138,7 +155,9 @@ ApplicationWindow {
 
     Component {
         id: app
-        AppMain {}
+        AppMain {
+            appSettings: applicationWindow.appSettings
+        }
     }
 
     Component {


### PR DESCRIPTION
Branched on top of: https://github.com/status-im/nim-status-client/pull/415

Adds the Settings element that enables to keep on disk some cool settings. Right now, I used it to keep the state of the SplitViews so that if you change the size of the split, it's gonna reopen to that state (you need to close the app with the X at the top, not with CTRL+C in the terminal, becuase otherwise the `onDestruction` events are not triggered)

This can be used for the window size, the language, etc.