### PR TITLE
fix QTDIR paths for CI

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -26,6 +26,8 @@ pipeline {
     NIMFLAGS = '--colors:off'
     /* Verbosity of make targets */
     V = "1"
+    /* Makefile assumes the compiler folder is included */
+    QTDIR = "/opt/qt/5.14.0/gcc_64"
     /* Control output the filename */
     STATUS_CLIENT_APPIMAGE = "pkg/${load('ci/lib.groovy').pkgFilename('linux', 'AppImage')}"
   }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -20,8 +20,8 @@ pipeline {
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Qt location is pre-defined */
-    QTDIR = '/usr/local/qt'
-    PATH = "${env.QTDIR}/clang_64/bin:${env.PATH}"
+    QTDIR = '/usr/local/qt/clang_64'
+    PATH = "${env.QTDIR}/bin:${env.PATH}"
     /* Control output the filename */
     STATUS_CLIENT_DMG = "pkg/${load('ci/lib.groovy').pkgFilename('macos', 'dmg')}"
   }


### PR DESCRIPTION
Fix for `QTDIR` in CI to include the compiler subfolder due to dfef4374f65bf2a8f29a8ac9e73649f9731b2c1b.

Successful builds:
* https://ci.status.im/job/nim-status-client/job/linux/job/fix-qt-in-ci/
* https://ci.status.im/job/nim-status-client/job/macos/job/fix-qt-in-ci/