### PR TITLE
Enable theme switching

### DIFF
--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -1,4 +1,5 @@
 import NimQml, json, eventemitter, strutils
+import json_serialization
 import ../../status/libstatus/mailservers as status_mailservers
 import ../../signals/types
 import ../../status/libstatus/types as status_types
@@ -8,6 +9,7 @@ import ../../status/[status, contacts]
 import ../../status/chat as status_chat
 import ../../status/chat/chat
 import view
+import chronicles
 
 type ProfileController* = ref object of SignalSubscriber
   view*: ProfileView
@@ -33,6 +35,8 @@ proc init*(self: ProfileController, account: Account) =
   let response = status_settings.getSettings()
   let pubKey = status_settings.getSetting[string]("public-key", "0x0")
   let mnemonic = status_settings.getSetting[string]("mnemonic", "")
+  let appearance = Json.decode($response["appearance"], int)
+  profile.appearance = appearance
   profile.id = pubKey
 
   self.view.setNewProfile(profile)

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -97,3 +97,7 @@ QtObject:
 
   proc qrCode*(self: ProfileView, text:string): string {.slot.} =
     result = "data:image/svg+xml;utf8," & generateQRCodeSVG(text, 2)
+
+  proc changeTheme*(self: ProfileView, theme: int) {.slot.} =
+    self.profile.setAppearance(theme)
+    self.status.saveSetting("appearance", $theme)

--- a/src/app/profile/views/profile_info.nim
+++ b/src/app/profile/views/profile_info.nim
@@ -6,6 +6,7 @@ QtObject:
     username*: string
     identicon*: string
     pubKey*: string
+    appearance*: int
 
   proc setup(self: ProfileInfoView) =
     self.QObject.setup
@@ -19,6 +20,7 @@ QtObject:
     result.pubKey = ""
     result.username = ""
     result.identicon = ""
+    result.appearance = 0
     result.setup
 
   proc profileChanged*(self: ProfileInfoView) {.signal.}
@@ -26,12 +28,22 @@ QtObject:
   proc setProfile*(self: ProfileInfoView, profile: Profile) =
     self.username = profile.username
     self.identicon = profile.identicon
+    self.appearance = profile.appearance
     self.pubKey = profile.id
     self.profileChanged()
 
   proc username*(self: ProfileInfoView): string {.slot.} = result = self.username
   QtProperty[string] username:
     read = username
+    notify = profileChanged
+
+  proc appearance*(self: ProfileInfoView): int {.slot.} = result = self.appearance
+  proc setAppearance*(self: ProfileInfoView, appearance: int) {.slot.} =
+    self.appearance = appearance
+    self.profileChanged()
+  QtProperty[int] appearance:
+    read = appearance
+    write = setAppearance
     notify = profileChanged
 
   proc identicon*(self: ProfileInfoView): string {.slot.} = result = self.identicon

--- a/src/status/profile/profile.nim
+++ b/src/status/profile/profile.nim
@@ -4,7 +4,7 @@ import ../libstatus/types
 type Profile* = ref object
   id*, alias*, username*, identicon*, address*, ensName*: string
   ensVerified*: bool
-  ensVerifiedAt*, ensVerificationRetries*: int
+  ensVerifiedAt*, ensVerificationRetries*, appearance*: int
   systemTags*: seq[string]
 
 proc isContact*(self: Profile): bool =
@@ -22,6 +22,7 @@ proc toProfileModel*(account: Account): Profile =
     ensName: "",
     ensVerified: false,
     ensVerifiedAt: 0,
+    appearance: 0,
     ensVerificationRetries: 0,
     systemTags: @[]
   )
@@ -39,6 +40,7 @@ proc toProfileModel*(profile: JsonNode): Profile =
     alias: profile["alias"].str,
     ensName: "",
     ensVerified: profile["ensVerified"].getBool,
+    appearance: 0,
     ensVerifiedAt: profile["ensVerifiedAt"].getInt,
     ensVerificationRetries: profile["ensVerificationRetries"].getInt,
     systemTags: systemTags

--- a/src/status/status.nim
+++ b/src/status/status.nim
@@ -57,3 +57,6 @@ proc reset*(self: Status) =
 
 proc getNodeVersion*(self: Status): string =
   libstatus_settings.getWeb3ClientVersion()
+
+proc saveSetting*(self: Status, setting: string, value: string) =
+  discard libstatus_settings.saveSettings(setting, value)

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -56,7 +56,7 @@ StackLayout {
                 anchors.fill: parent
                 anchors.leftMargin:  -border.width
                 border.width: 1
-                border.color: Theme.grey
+                border.color: Style.current.grey
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatButtons.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatButtons.qml
@@ -12,7 +12,7 @@ Rectangle {
         width: 30
         height: 30
         text: ""
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
         onClicked: {
@@ -20,7 +20,7 @@ Rectangle {
             txtData.text = ""
         }
         background: Rectangle {
-            color: parent.enabled ? Theme.blue : Theme.grey
+            color: parent.enabled ? Style.current.blue : Style.current.grey
             radius: 50
         }
         Image {
@@ -37,7 +37,7 @@ Rectangle {
         visible: txtData.length == 0
         width: 20
         height: 20
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         anchors.right: parent.right
         fillMode: Image.PreserveAspectFit
         source: "../../../img/stickers_icon" + (stickersPopup.opened ? "_open.svg" : ".svg")

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
@@ -46,9 +46,9 @@ Rectangle {
                 id: txtData
                 text: ""
                 selectByMouse: true
-                topPadding: Theme.padding
+                topPadding: Style.current.padding
                 leftPadding: 12
-                rightPadding: Theme.padding
+                rightPadding: Style.current.padding
                 font.pixelSize: 14
                 placeholderText: qsTr("Type a message...")
                 Keys.onPressed: onEnter(event)
@@ -62,8 +62,8 @@ Rectangle {
             id: sendBtns
             Layout.topMargin: 1
             Layout.fillHeight: true
-            Layout.preferredWidth: 30 + Theme.padding
-            Layout.minimumWidth: 30 + Theme.padding
+            Layout.preferredWidth: 30 + Style.current.padding
+            Layout.minimumWidth: 30 + Style.current.padding
             Layout.maximumWidth: 200
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/EmptyChat.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/EmptyChat.qml
@@ -26,7 +26,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             font.weight: Font.DemiBold
             font.pixelSize: 15
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -71,10 +71,10 @@ Item {
             height: 120
             radius: 120
             border.width: chatsModel.activeChannel.chatType == Constants.chatTypeOneToOne ? 2 : 0
-            border.color: Theme.grey
+            border.color: Style.current.grey
             color: {
                 if (chatsModel.activeChannel.chatType == Constants.chatTypeOneToOne) {
-                    return Theme.transparent
+                    return Style.current.transparent
                 }
                 return chatsModel.activeChannel.color
             }
@@ -116,7 +116,7 @@ Item {
                 }
             font.weight: Font.Bold
             font.pixelSize: 22
-            color: Theme.black
+            color: Style.current.black
             anchors.top: circleId.bottom
             anchors.topMargin: 16
             anchors.horizontalCenter: parent.horizontalCenter
@@ -132,7 +132,7 @@ Item {
                 id: joinChat
                 text: qsTr("Join chat")
                 font.pixelSize: 20
-                color: Theme.blue
+                color: Style.current.blue
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 MouseArea {
@@ -147,10 +147,10 @@ Item {
             StyledText {
                 text: qsTr("Decline invitation")
                 font.pixelSize: 20
-                color: Theme.blue
+                color: Style.current.blue
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: joinChat.bottom
-                anchors.topMargin: Theme.padding
+                anchors.topMargin: Style.current.padding
                 MouseArea {
                     cursorShape: Qt.PointingHandCursor
                     anchors.fill: parent
@@ -169,7 +169,7 @@ Item {
         text:  message
         visible: isStatusMessage
         font.pixelSize: 16
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         width:  parent.width - 120
         horizontalAlignment: Text.AlignHCenter
         anchors.horizontalCenter: parent.horizontalCenter
@@ -183,7 +183,7 @@ Item {
         height: 36
         anchors.topMargin: 20
         anchors.left: parent.left
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
         anchors.top: parent.top
         fillMode: Image.PreserveAspectFit
         source: identicon
@@ -229,14 +229,14 @@ Item {
 
         id: chatBox
         height: (2 * chatVerticalPadding) + (contentType == Constants.stickerType ? stickerId.height : chatText.height)
-        color: isCurrentUser ? Theme.blue : Theme.lightBlue
-        border.color: Theme.transparent
+        color: isCurrentUser ? Style.current.blue : Style.current.lightBlue
+        border.color: Style.current.transparent
         width: contentType === Constants.stickerType ? (stickerId.width + (2 * chatHorizontalPadding)) : (message.length > 52 ? 380 : chatText.width + 2 * chatHorizontalPadding)
         radius: 16
         anchors.left: !isCurrentUser ? chatImage.right : undefined
         anchors.leftMargin: !isCurrentUser ? 8 : 0
         anchors.right: !isCurrentUser ? undefined : parent.right
-        anchors.rightMargin: !isCurrentUser ? 0 : Theme.padding
+        anchors.rightMargin: !isCurrentUser ? 0 : Style.current.padding
         anchors.top: authorCurrentMsg != authorPrevMsg && !isCurrentUser ? chatImage.top : parent.top
         anchors.topMargin: 0
         visible: isMessage || isEmoji
@@ -279,7 +279,7 @@ Item {
             font.pixelSize: 15
             readOnly: true
             selectByMouse: true
-            color: !isCurrentUser ? Theme.black : Theme.white
+            color: !isCurrentUser ? Style.current.black : Style.current.white
             visible: contentType == Constants.messageType || isEmoji
             onLinkActivated: {
                 if(link.startsWith("#")){
@@ -311,7 +311,7 @@ Item {
 
         StyledTextEdit {
             id: chatTime
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             text: {
                 let messageDate = new Date(Math.floor(timestamp))
                 let minutes = messageDate.getMinutes();
@@ -320,9 +320,9 @@ Item {
             }
             anchors.top: contentType === Constants.stickerType ? stickerId.bottom : chatText.bottom
             anchors.topMargin: 8
-            anchors.bottomMargin: Theme.padding
+            anchors.bottomMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: isCurrentUser ? 5 : Theme.padding
+            anchors.rightMargin: isCurrentUser ? 5 : Style.current.padding
             font.pixelSize: 10
             readOnly: true
             selectByMouse: true
@@ -332,12 +332,12 @@ Item {
 
         StyledTextEdit {
             id: sentMessage
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             text: qsTr("Sent")
             anchors.top: contentType === Constants.stickerType ? stickerId.bottom : chatText.bottom
-            anchors.bottomMargin: Theme.padding
+            anchors.bottomMargin: Style.current.padding
             anchors.right: chatTime.left
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             font.pixelSize: 10
             readOnly: true
             visible: isCurrentUser && outgoingStatus == "sent"

--- a/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
@@ -12,7 +12,7 @@ Rectangle {
     color: "white"
     height: 56
     Layout.fillWidth: true
-    border.color: Theme.grey
+    border.color: Style.current.grey
     border.width: 1
 
     ChannelIcon {
@@ -28,9 +28,9 @@ Rectangle {
         height: 20
         text: chatsModel.activeChannel.chatType != Constants.chatTypePublic ? chatsModel.activeChannel.name : channelNameStr
         anchors.left: channelIcon.right
-        anchors.leftMargin: Theme.smallPadding
+        anchors.leftMargin: Style.current.smallPadding
         anchors.top: parent.top
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         font.weight: Font.Medium
         font.pixelSize: 15
         selectByMouse: true
@@ -39,7 +39,7 @@ Rectangle {
 
     StyledText {
         id: channelIdentifier
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         text: {
             switch(chatsModel.activeChannel.chatType){
                 case Constants.chatTypePublic: return qsTr("Public chat")
@@ -53,7 +53,7 @@ Rectangle {
         }
         font.pixelSize: 12
         anchors.left: channelIcon.right
-        anchors.leftMargin: Theme.smallPadding
+        anchors.leftMargin: Style.current.smallPadding
         anchors.top: channelName.bottom
         anchors.topMargin: 0
     }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -16,9 +16,9 @@ SplitView {
 
     ContactsColumn {
         id: contactsColumn
-        SplitView.preferredWidth: Theme.leftTabPrefferedSize
-        SplitView.minimumWidth: Theme.leftTabMinimumWidth
-        SplitView.maximumWidth: Theme.leftTabMaximumWidth
+        SplitView.preferredWidth: Style.current.leftTabPrefferedSize
+        SplitView.minimumWidth: Style.current.leftTabMinimumWidth
+        SplitView.maximumWidth: Style.current.leftTabMaximumWidth
     }
 
     ChatColumn {

--- a/ui/app/AppLayouts/Chat/ContactsColumn.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn.qml
@@ -42,15 +42,15 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 59
         anchors.right: addChat.left
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         anchors.left: parent.left
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
     }
 
     AddChat {
         id: addChat
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         anchors.top: parent.top
         anchors.topMargin: 59
     }

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -13,7 +13,7 @@ Rectangle {
     property string searchStr: ""
 
     id: wrapper
-    color: ListView.isCurrentItem ? Theme.lightBlue : Theme.transparent
+    color: ListView.isCurrentItem ? Style.current.lightBlue : Style.current.transparent
     anchors.right: parent.right
     anchors.top: applicationWindow.top
     anchors.left: parent.left
@@ -50,9 +50,9 @@ Rectangle {
         fillMode: Image.PreserveAspectFit
         source: "../../../img/channel-icon-" + (wrapper.chatType === Constants.chatTypePublic ? "public-chat.svg" : "group.svg")
         anchors.left: contactImage.right
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
         anchors.top: parent.top
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         visible: wrapper.chatType !== Constants.chatTypeOneToOne
     }
 
@@ -60,14 +60,14 @@ Rectangle {
         id: contactInfo
         text: wrapper.chatType !== Constants.chatTypePublic ? Emoji.parse(wrapper.name, "26x26") : "#" + wrapper.name
         anchors.right: contactTime.left
-        anchors.rightMargin: Theme.smallPadding
+        anchors.rightMargin: Style.current.smallPadding
         elide: Text.ElideRight
         font.weight: Font.Medium
         font.pixelSize: 15
         anchors.left: channelIcon.visible ? channelIcon.right : contactImage.right
-        anchors.leftMargin: channelIcon.visible ? 2 : Theme.padding
+        anchors.leftMargin: channelIcon.visible ? 2 : Style.current.padding
         anchors.top: parent.top
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         color: "black"
     }
     
@@ -75,14 +75,14 @@ Rectangle {
         id: lastChatMessage
         text: lastMessage ? Emoji.parse(lastMessage, "26x26").replace(/\n|\r/g, ' ') : qsTr("No messages")
         anchors.right: contactNumberChatsCircle.left
-        anchors.rightMargin: Theme.smallPadding
+        anchors.rightMargin: Style.current.smallPadding
         elide: Text.ElideRight
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Theme.smallPadding
+        anchors.bottomMargin: Style.current.smallPadding
         font.pixelSize: 15
         anchors.left: contactImage.right
-        anchors.leftMargin: Theme.padding
-        color: Theme.darkGrey
+        anchors.leftMargin: Style.current.padding
+        color: Style.current.darkGrey
     }
     StyledText {
         id: contactTime
@@ -109,11 +109,11 @@ Rectangle {
           }
         }
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         anchors.top: parent.top
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         font.pixelSize: 11
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
     Rectangle {
         id: contactNumberChatsCircle
@@ -121,10 +121,10 @@ Rectangle {
         height: 22
         radius: 50
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Theme.smallPadding
+        anchors.bottomMargin: Style.current.smallPadding
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
-        color: Theme.blue
+        anchors.rightMargin: Style.current.padding
+        color: Style.current.blue
         visible: unviewedMessagesCount > 0
         StyledText {
             id: contactNumberChats

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
@@ -18,8 +18,8 @@ Item {
         anchors.bottom: parent.bottom
         anchors.right: parent.right
         anchors.left: parent.left
-        anchors.rightMargin: Theme.padding
-        anchors.leftMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
         model: chatsModel.chats
         delegate: Channel {
             name: model.name

--- a/ui/app/AppLayouts/Chat/components/ChannelIcon.qml
+++ b/ui/app/AppLayouts/Chat/components/ChannelIcon.qml
@@ -5,8 +5,8 @@ import "../../../../imports"
 import "../../../../shared"
 
 Rectangle {
-  property int topMargin: Theme.smallPadding
-  property int bottomMargin: Theme.smallPadding
+  property int topMargin: Style.current.smallPadding
+  property int bottomMargin: Style.current.smallPadding
   property string channelName
   property int channelType
   property string channelIdenticon
@@ -14,7 +14,7 @@ Rectangle {
   width: 36
   height: 36
   anchors.left: parent.left
-  anchors.leftMargin: Theme.padding
+  anchors.leftMargin: Style.current.padding
   anchors.top: parent.top
   anchors.topMargin: topMargin
   anchors.bottom: parent.bottom
@@ -35,7 +35,7 @@ Rectangle {
       color: {
           const color = chatsModel.getChannelColor(channelName)
           if (!color) {
-              return Theme.transparent
+              return Style.current.transparent
           }
           return color
       }
@@ -66,7 +66,7 @@ Rectangle {
       radius: 50
       border.color: "#10000000"
       border.width: 1
-      color: Theme.transparent
+      color: Style.current.transparent
       SVGImage {
           width: contactImage.width ? contactImage.width : 40
           height: contactImage.height ? contactImage.height : 40

--- a/ui/app/AppLayouts/Chat/components/Contact.qml
+++ b/ui/app/AppLayouts/Chat/components/Contact.qml
@@ -26,7 +26,7 @@ Rectangle {
     anchors.right: parent.right
     anchors.left: parent.left
     border.width: 0
-    radius: Theme.radius
+    radius: Style.current.radius
 
     Identicon {
         id: accountImage
@@ -40,12 +40,12 @@ Rectangle {
         text: name
         elide: Text.ElideRight
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         font.pixelSize: 17
         anchors.top: accountImage.top
         anchors.topMargin: 10
         anchors.left: accountImage.right
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
     }
 
     SVGImage {
@@ -56,7 +56,7 @@ Rectangle {
         anchors.top: accountImage.top
         anchors.topMargin: 6
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         fillMode: Image.PreserveAspectFit
         source: "../../../img/list-next.svg"
         MouseArea {
@@ -74,7 +74,7 @@ Rectangle {
         anchors.top: accountImage.top
         anchors.topMargin: 6
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         checked: isChecked
         onClicked: {
             isChecked = !isChecked
@@ -86,9 +86,9 @@ Rectangle {
         visible: isUser
         text: qsTr("Admin")
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         font.pixelSize: 15
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         anchors.top: accountImage.top
         anchors.topMargin: 10
     }

--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -64,13 +64,13 @@ ModalPopup {
           font.bold: true
           font.pixelSize: 17
           anchors.top: parent.top
-          anchors.topMargin: Theme.padding
+          anchors.topMargin: Style.current.padding
       }
 
       StyledText {
           anchors.top: lblNewGroup.bottom
           text: qsTr("%1 / 10 members").arg(memberCount)
-          color: Theme.darkGrey
+          color: Style.current.darkGrey
           font.pixelSize: 15
       }
     }

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -58,7 +58,7 @@ ModalPopup {
           height: 36
           radius: 50
           anchors.top: parent.top
-          anchors.topMargin: Theme.padding
+          anchors.topMargin: Style.current.padding
           color: chatsModel.activeChannel.color
   
           StyledText {
@@ -66,7 +66,7 @@ ModalPopup {
             opacity: 0.7
             font.weight: Font.Bold
             font.pixelSize: 21
-            color: Theme.white
+            color: Style.current.white
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
           }
@@ -78,7 +78,7 @@ ModalPopup {
           anchors.top: parent.top
           anchors.topMargin: 18
           anchors.left: letterIdenticon.right
-          anchors.leftMargin: Theme.smallPadding
+          anchors.leftMargin: Style.current.smallPadding
           font.bold: true
           font.pixelSize: 14
           readOnly: true
@@ -97,11 +97,11 @@ ModalPopup {
           }
           width: 160
           anchors.left: letterIdenticon.right
-          anchors.leftMargin: Theme.smallPadding
+          anchors.leftMargin: Style.current.smallPadding
           anchors.top: groupName.bottom
           anchors.topMargin: 2
           font.pixelSize: 14
-          color: Theme.darkGrey
+          color: Style.current.darkGrey
       }
 
       Rectangle {
@@ -110,7 +110,7 @@ ModalPopup {
             height: 24
             width: 24
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.leftMargin: 4
             anchors.left: groupName.right
             radius: 8
@@ -128,10 +128,10 @@ ModalPopup {
                 anchors.fill: parent
                 hoverEnabled: true
                 onExited: {
-                    editGroupNameBtn.color = Theme.white
+                    editGroupNameBtn.color = Style.current.white
                 }
                 onEntered: {
-                    editGroupNameBtn.color = Theme.grey
+                    editGroupNameBtn.color = Style.current.grey
                 }
                 onClicked: renameGroupPopup.open()
             }
@@ -210,9 +210,9 @@ ModalPopup {
             id: memberLabel
             text: qsTr("Members")
             anchors.left: parent.left
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             font.pixelSize: 15
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
         }
 
         ListModel {
@@ -249,7 +249,7 @@ ModalPopup {
             anchors.top: memberLabel.bottom
             anchors.bottom: popup.bottom
             anchors.topMargin: 30
-            anchors.bottomMargin: Theme.padding
+            anchors.bottomMargin: Style.current.padding
             spacing: 4
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -300,7 +300,7 @@ ModalPopup {
                                 }
                                 Action {
                                     icon.source: "../../../img/remove-from-group.svg"
-                                    icon.color: Theme.red
+                                    icon.color: Style.current.red
                                     text: qsTr("Remove From Group")
                                     onTriggered: chatsModel.kickGroupMember(chatsModel.activeChannel.id,  model.pubKey)
                                 }

--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -71,8 +71,8 @@ ModalPopup {
     Text {
         id: ensUsername
         anchors.top: chatKey.bottom
-        anchors.topMargin: Theme.padding
-        color: Theme.darkGrey
+        anchors.topMargin: Style.current.padding
+        color: Style.current.darkGrey
         font.pixelSize: 12
     }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -32,9 +32,9 @@ ModalPopup {
             radius: 30
             border.color: "#10000000"
             border.width: 1
-            color: Theme.transparent
+            color: Style.current.transparent
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             SVGImage {
                 width: parent.width
                 height: parent.height
@@ -49,7 +49,7 @@ ModalPopup {
             anchors.top: parent.top
             anchors.topMargin: 18
             anchors.left: profilePic.right
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             font.bold: true
             font.pixelSize: 14
             readOnly: true
@@ -61,11 +61,11 @@ ModalPopup {
             width: 160
             elide: Text.ElideMiddle
             anchors.left: profilePic.right
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: profileName.bottom
             anchors.topMargin: 2
             font.pixelSize: 14
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
         }
 
         Rectangle {
@@ -73,9 +73,9 @@ ModalPopup {
             height: 32
             width: 32
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: 32 + Theme.smallPadding
+            anchors.rightMargin: 32 + Style.current.smallPadding
             radius: 8
 
             SVGImage {
@@ -91,10 +91,10 @@ ModalPopup {
                 anchors.fill: parent
                 hoverEnabled: true
                 onExited: {
-                    qrCodeButton.color = Theme.white
+                    qrCodeButton.color = Style.current.white
                 }
                 onEntered: {
-                    qrCodeButton.color = Theme.grey
+                    qrCodeButton.color = Style.current.grey
                 }
                 onClicked: {
                     showQR = true
@@ -130,11 +130,11 @@ ModalPopup {
             text: qsTr("ENS username")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: parent.top
-            anchors.topMargin: Theme.smallPadding
+            anchors.topMargin: Style.current.smallPadding
         }
 
         StyledText {
@@ -144,9 +144,9 @@ ModalPopup {
             text: userName
             font.pixelSize: 14
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelEnsUsername.bottom
-            anchors.topMargin: Theme.smallPadding
+            anchors.topMargin: Style.current.smallPadding
         }
 
         CopyToClipBoardIcon {
@@ -154,7 +154,7 @@ ModalPopup {
           height: isEnsVerified ? 20 : 0
           anchors.top: labelEnsUsername.bottom
           anchors.left: valueEnsName.right
-          anchors.leftMargin: Theme.smallPadding
+          anchors.leftMargin: Style.current.smallPadding
           onClick: function (){
             chatsModel.copyToClipboard(valueEnsName.text)
           }
@@ -165,11 +165,11 @@ ModalPopup {
             text: qsTr("Chat key")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: isEnsVerified ? valueEnsName.bottom : parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
         }
 
         StyledText {
@@ -179,15 +179,15 @@ ModalPopup {
             elide: Text.ElideMiddle
             font.pixelSize: 14
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelChatKey.bottom
-            anchors.topMargin: Theme.smallPadding
+            anchors.topMargin: Style.current.smallPadding
         }
 
         CopyToClipBoardIcon {
           anchors.top: labelChatKey.bottom
           anchors.left: valueChatKey.right
-          anchors.leftMargin: Theme.smallPadding
+          anchors.leftMargin: Style.current.smallPadding
           onClick: function (){
             chatsModel.copyToClipboard(valueChatKey.text)
           }
@@ -196,11 +196,11 @@ ModalPopup {
         Separator {
             id: separator
             anchors.top: valueChatKey.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.left: parent.left
-            anchors.leftMargin: -Theme.padding
+            anchors.leftMargin: -Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: -Theme.padding
+            anchors.rightMargin: -Style.current.padding
         }
 
         StyledText {
@@ -208,11 +208,11 @@ ModalPopup {
             text: qsTr("Share Profile URL")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: separator.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
         }
 
         StyledText {
@@ -221,15 +221,15 @@ ModalPopup {
                       0, 4) + "..." + fromAuthor.substr(fromAuthor.length - 5)
             font.pixelSize: 14
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelShareURL.bottom
-            anchors.topMargin: Theme.smallPadding
+            anchors.topMargin: Style.current.smallPadding
         }
 
         CopyToClipBoardIcon {
           anchors.top: labelShareURL.bottom
           anchors.left: valueShareURL.right
-          anchors.leftMargin: Theme.smallPadding
+          anchors.leftMargin: Style.current.smallPadding
           onClick: function (){
             chatsModel.copyToClipboard("https://join.status.im/u/" + fromAuthor)
           }
@@ -258,8 +258,8 @@ ModalPopup {
             anchors.rightMargin: addToContactsButton.width + 32
             btnColor: "white"
             btnBorderWidth: 1
-            btnBorderColor: Theme.grey
-            textColor: Theme.red
+            btnBorderColor: Style.current.grey
+            textColor: Style.current.red
             label: qsTr("Block User")
             anchors.bottom: parent.bottom
             onClicked: {
@@ -273,7 +273,7 @@ ModalPopup {
         StyledButton {
             id: addToContactsButton
             anchors.right: parent.right
-            anchors.rightMargin: Theme.smallPadding
+            anchors.rightMargin: Style.current.smallPadding
             label: profileModel.isAdded(
                        fromAuthor) ? qsTr("Remove Contact") : qsTr(
                                          "Add to contacts")

--- a/ui/app/AppLayouts/Chat/components/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PublicChatPopup.qml
@@ -39,7 +39,7 @@ ModalPopup {
     Input {
         id: channelName
         anchors.top: description.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         placeholderText: qsTr("chat-name")
         Keys.onEnterPressed: doJoin()
         Keys.onReturnPressed: doJoin()

--- a/ui/app/AppLayouts/Chat/components/RenameGroupPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/RenameGroupPopup.qml
@@ -30,7 +30,7 @@ Popup {
     width: 480
     height: 159
     background: Rectangle {
-        color: Theme.white
+        color: Style.current.white
         radius: 8
     }
     padding: 0
@@ -43,8 +43,8 @@ Popup {
             anchors.left: parent.left
             font.pixelSize: 13
             anchors.leftMargin: 16
-            anchors.topMargin: Theme.padding
-            anchors.bottomMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
+            anchors.bottomMargin: Style.current.padding
         }
 
         Input {
@@ -52,9 +52,9 @@ Popup {
             anchors.top: groupTitleLabel.bottom
             anchors.topMargin: 7
             anchors.left: parent.left
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             placeholderText: qsTr("Group Name")
             Keys.onEnterPressed: doRename()
             Keys.onReturnPressed: doRename()
@@ -65,7 +65,7 @@ Popup {
             anchors.top: groupName.bottom
             anchors.topMargin: 22
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             label: qsTr("Save")
             onClicked : doRename()
         }

--- a/ui/app/AppLayouts/Chat/components/StickersPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/StickersPopup.qml
@@ -15,7 +15,7 @@ Popup {
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
     background: Rectangle {
         radius: 8
-        border.color: Theme.grey
+        border.color: Style.current.grey
         layer.enabled: true
         layer.effect: DropShadow{
             verticalOffset: 3
@@ -87,7 +87,7 @@ Popup {
                     visible: stickerPackListView.count <= 0
                     label: qsTr("Get Stickers")
                     anchors.top: noStickersContainer.bottom
-                    anchors.topMargin: Theme.padding
+                    anchors.topMargin: Style.current.padding
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
             }
@@ -148,10 +148,10 @@ Popup {
             RoundedIcon {
                 id: btnHistory
                 size: 24
-                color: Theme.darkGrey
+                color: Style.current.darkGrey
                 imgPath: "../../../img/history_icon.svg"
                 anchors.left: btnAddStickerPack.right
-                anchors.leftMargin: Theme.padding
+                anchors.leftMargin: Style.current.padding
                 onClicked: {
                     chatsModel.setActiveStickerPackById(-1)
                     packIndicator.updatePosition(-1)
@@ -159,10 +159,10 @@ Popup {
             }
 
             RowLayout {
-                spacing: Theme.padding
+                spacing: Style.current.padding
                 anchors.top: parent.top
                 anchors.left: btnHistory.right
-                anchors.leftMargin: Theme.padding
+                anchors.leftMargin: Style.current.padding
 
                 Repeater {
                     id: stickerPackListView
@@ -184,7 +184,7 @@ Popup {
             }
             Rectangle {
                 id: packIndicator
-                border.color: Theme.blue
+                border.color: Style.current.blue
                 border.width: 1
                 height: 2
                 width: 16

--- a/ui/app/AppLayouts/Chat/components/SuggestedChannel.qml
+++ b/ui/app/AppLayouts/Chat/components/SuggestedChannel.qml
@@ -9,12 +9,12 @@ Rectangle {
     radius: 8
     width: children[0].width + 10
     height: 32
-    border.color: Theme.grey
+    border.color: Style.current.grey
     StyledText {
         id: suggestedChannelText
         text: "#" + channel
         font.weight: Font.Medium
-        color: Theme.blue;
+        color: Style.current.blue;
         anchors.top: parent.top;
         anchors.topMargin: 5;
         anchors.left: parent.left;

--- a/ui/app/AppLayouts/Node/NodeLayout.qml
+++ b/ui/app/AppLayouts/Node/NodeLayout.qml
@@ -19,20 +19,20 @@ Item {
             Layout.fillHeight: true
             StyledText {
                 id: testDescription
-                color: Theme.lightBlueText
+                color: Style.current.lightBlueText
                 text: "latest block (auto updates):"
-                Layout.rightMargin: Theme.padding
-                Layout.leftMargin: Theme.padding
+                Layout.rightMargin: Style.current.padding
+                Layout.leftMargin: Style.current.padding
                 Layout.fillWidth: true
                 font.weight: Font.Medium
                 font.pixelSize: 20
             }
             StyledText {
                 id: test
-                color: Theme.lightBlueText
+                color: Style.current.lightBlueText
                 text: nodeModel.lastMessage
-                Layout.rightMargin: Theme.padding
-                Layout.leftMargin: Theme.padding
+                Layout.rightMargin: Style.current.padding
+                Layout.leftMargin: Style.current.padding
                 Layout.fillWidth: true
                 font.weight: Font.Medium
                 font.pixelSize: 20
@@ -42,8 +42,8 @@ Item {
         RowLayout {
             id: resultContainer
             Layout.fillHeight: true
-            Layout.rightMargin: Theme.padding
-            Layout.leftMargin: Theme.padding
+            Layout.rightMargin: Style.current.padding
+            Layout.leftMargin: Style.current.padding
             TextArea { id: callResult; Layout.fillWidth: true; text: nodeModel.callResult; readOnly: true }
         }
 
@@ -64,7 +64,7 @@ Item {
                 Rectangle {
                     id: rectangle
                     color: "#00000000"
-                    border.color: Theme.grey
+                    border.color: Style.current.grey
                     anchors.fill: parent
 
                     Button {
@@ -85,7 +85,7 @@ Item {
                         }
                         enabled: txtData.text !== ""
                         background: Rectangle {
-                            color: parent.enabled ? Theme.blue : Theme.grey
+                            color: parent.enabled ? Style.current.blue : Style.current.grey
                             radius: 50
                         }
                     }

--- a/ui/app/AppLayouts/Profile/LeftTab/Menu.qml
+++ b/ui/app/AppLayouts/Profile/LeftTab/Menu.qml
@@ -36,7 +36,7 @@ Rectangle {
             anchors.top: parent.top
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -61,7 +61,7 @@ Rectangle {
             anchors.top: ensTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -86,7 +86,7 @@ Rectangle {
             anchors.top: contactsTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -112,7 +112,7 @@ Rectangle {
             anchors.top: privacyTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -138,7 +138,7 @@ Rectangle {
             anchors.top: syncTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -164,7 +164,7 @@ Rectangle {
             anchors.top: languageTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -189,7 +189,7 @@ Rectangle {
             anchors.top: notificationsTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -215,7 +215,7 @@ Rectangle {
             anchors.top: advancedTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -240,7 +240,7 @@ Rectangle {
             anchors.top: helpTabButton.bottom
             anchors.topMargin: 0
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {
@@ -265,7 +265,7 @@ Rectangle {
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 20
             background: Rectangle {
-                color: Theme.transparent
+                color: Style.current.transparent
             }
 
             StyledText {

--- a/ui/app/AppLayouts/Profile/LeftTab/Profile.qml
+++ b/ui/app/AppLayouts/Profile/LeftTab/Profile.qml
@@ -61,7 +61,7 @@ Rectangle {
         StyledText {
             id: pubkeyText
             text: pubkey
-            font.family: Theme.fontHexRegular.name
+            font.family: Style.current.fontHexRegular.name
             width: 208
             elide: Text.ElideMiddle
             anchors.top: profileName.bottom

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -19,9 +19,9 @@ SplitView {
 
     LeftTab {
         id: leftTab
-        SplitView.preferredWidth: Theme.leftTabPrefferedSize
-        SplitView.minimumWidth: Theme.leftTabMinimumWidth
-        SplitView.maximumWidth: Theme.leftTabMaximumWidth
+        SplitView.preferredWidth: Style.current.leftTabPrefferedSize
+        SplitView.minimumWidth: Style.current.leftTabMinimumWidth
+        SplitView.maximumWidth: Style.current.leftTabMaximumWidth
     }
 
     StackLayout {

--- a/ui/app/AppLayouts/Profile/Sections/AboutContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/AboutContainer.qml
@@ -94,7 +94,7 @@ Item {
         font.letterSpacing: 0.1
         width: 700
         wrapMode: Text.Wrap
-        color: Theme.black
+        color: Style.current.black
     }
 }
 

--- a/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
@@ -12,7 +12,7 @@ Item {
     Layout.fillWidth: true
 
     StyledText {
-        id: element7
+        id: title
         text: qsTr("Advanced settings")
         anchors.left: parent.left
         anchors.leftMargin: 24
@@ -23,8 +23,32 @@ Item {
     }
 
     RowLayout {
+        // TODO move this to a new panel once we have the appearance panel
+        property bool isDarkTheme: false
+        id: themeSetting
+        anchors.top: title.bottom
+        anchors.topMargin: 20
+        anchors.left: parent.left
+        anchors.leftMargin: 24
+        StyledText {
+            text: qsTr("Theme (Light - Dark)")
+        }
+        Switch {
+            checked: themeSetting.isDarkTheme
+            onCheckedChanged: function(value) {
+                themeSetting.isDarkTheme = !themeSetting.isDarkTheme
+                if (themeSetting.isDarkTheme) {
+                    Style.changeTheme('dark')
+                } else {
+                    Style.changeTheme('light')
+                }
+            }
+        }
+    }
+
+    RowLayout {
         id: walletTabSettings
-        anchors.top: element7.bottom
+        anchors.top: themeSetting.bottom
         anchors.topMargin: 20
         anchors.left: parent.left
         anchors.leftMargin: 24

--- a/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
@@ -24,7 +24,15 @@ Item {
 
     RowLayout {
         // TODO move this to a new panel once we have the appearance panel
-        property bool isDarkTheme: false
+        property bool isDarkTheme: {
+            const isDarkTheme = profileModel.profile.appearance === 1
+            if (isDarkTheme) {
+                Style.changeTheme('dark')
+            } else {
+                Style.changeTheme('light')
+            }
+            return isDarkTheme
+        }
         id: themeSetting
         anchors.top: title.bottom
         anchors.topMargin: 20
@@ -36,12 +44,7 @@ Item {
         Switch {
             checked: themeSetting.isDarkTheme
             onCheckedChanged: function(value) {
-                themeSetting.isDarkTheme = !themeSetting.isDarkTheme
-                if (themeSetting.isDarkTheme) {
-                    Style.changeTheme('dark')
-                } else {
-                    Style.changeTheme('light')
-                }
+                profileModel.changeTheme(themeSetting.isDarkTheme ? 0 : 1)
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
@@ -21,12 +21,12 @@ ModalPopup {
         id: wrapper
         property int len: profileModel.mnemonic.split(" ").length
         anchors.top: parent.top
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         height: 40*(len/2)
         width: 350
         border.width: 1
-        border.color: Theme.grey
-        radius: Theme.radius
+        border.color: Style.current.grey
+        radius: Style.current.radius
         anchors.horizontalCenter: parent.horizontalCenter
 
         Repeater {
@@ -47,18 +47,18 @@ ModalPopup {
               anchors.bottom: parent.bottom
               anchors.right: parent.right
               anchors.rightMargin: 175
-              color: Theme.grey
+              color: Style.current.grey
               visible: index >= wrapper.len/2
             }
 
             Text {
               id: count
               text: index+1
-              color: Theme.darkGrey
+              color: Style.current.darkGrey
               anchors.bottom: parent.bottom
-              anchors.bottomMargin: Theme.smallPadding
+              anchors.bottomMargin: Style.current.smallPadding
               anchors.left: parent.left
-              anchors.leftMargin: Theme.bigPadding
+              anchors.leftMargin: Style.current.bigPadding
               font.pixelSize: 15
             }
 
@@ -66,9 +66,9 @@ ModalPopup {
               text: modelData
               font.pixelSize: 15
               anchors.bottom: parent.bottom
-              anchors.bottomMargin: Theme.smallPadding
+              anchors.bottomMargin: Style.current.smallPadding
               anchors.left: count.right
-              anchors.leftMargin: Theme.padding
+              anchors.leftMargin: Style.current.padding
               selectByMouse: true
               readOnly: true
             }
@@ -83,20 +83,20 @@ ModalPopup {
       text: qsTr("With this 12 words you can always get your key back. Write it down. Keep it safe, offline, and separate from this device.")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
       anchors.bottom: parent.bottom
-      anchors.bottomMargin: Theme.padding
+      anchors.bottomMargin: Style.current.padding
       anchors.left: parent.left
-      anchors.leftMargin: Theme.smallPadding
+      anchors.leftMargin: Style.current.smallPadding
       anchors.right: parent.right
-      anchors.rightMargin: Theme.smallPadding
+      anchors.rightMargin: Style.current.smallPadding
       wrapMode: Text.WordWrap
     }
 
     footer: StyledButton {
       label: qsTr("Done")
       anchors.right: parent.right
-      anchors.rightMargin: Theme.smallPadding
+      anchors.rightMargin: Style.current.smallPadding
       anchors.bottom: parent.bottom
       onClicked: {
         backupSeedModal.close()

--- a/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
@@ -17,12 +17,12 @@ Rectangle {
     anchors.right: parent.right
     anchors.left: parent.left
     border.width: 0
-    radius: Theme.radius
+    radius: Style.current.radius
 
     Identicon {
         id: accountImage
         anchors.left: parent.left
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
         source: identicon
     }
@@ -31,16 +31,16 @@ Rectangle {
         text: name
         elide: Text.ElideRight
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         font.pixelSize: 17
         anchors.top: accountImage.top
         anchors.left: accountImage.right
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
     }
     StyledText {
         id: addressText
         width: 108
-        font.family: Theme.fontHexRegular.name
+        font.family: Style.current.fontHexRegular.name
         text: address
         elide: Text.ElideMiddle
         anchors.bottom: accountImage.bottom
@@ -48,12 +48,12 @@ Rectangle {
         anchors.left: usernameText.left
         anchors.leftMargin: 0
         font.pixelSize: 15
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
     RadioButton {
         visible: selectable
         anchors.top: parent.top
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         anchors.right: parent.right
         ButtonGroup.group: contactGroup
     }

--- a/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
@@ -27,18 +27,18 @@ Item {
       text: qsTr("Security")
       font.pixelSize: 13
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
       anchors.left: parent.left
-      anchors.leftMargin: Theme.bigPadding
+      anchors.leftMargin: Style.current.bigPadding
       anchors.top: element3.bottom
-      anchors.topMargin: Theme.smallPadding
+      anchors.topMargin: Style.current.smallPadding
     }
 
     Item {
       anchors.top: labelSecurity.bottom
-      anchors.topMargin: Theme.padding
+      anchors.topMargin: Style.current.padding
       anchors.left: parent.left
-      anchors.leftMargin: Theme.bigPadding
+      anchors.leftMargin: Style.current.bigPadding
       height: children[0].height
       width: children[0].width
       Text {

--- a/ui/app/AppLayouts/Profile/Sections/SignoutContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/SignoutContainer.qml
@@ -25,7 +25,7 @@ Item {
     StyledButton {
         id: btnLogout
         anchors.top: txtTitle.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         // label: qsTr("Logout")
         label: qsTr("Exit")
 

--- a/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
@@ -85,7 +85,7 @@ ModalPopup {
         id: addressText
         label: qsTr("Wallet address")
         text: currentAccount.address
-        fontFamily: Theme.fontHexRegular.name
+        fontFamily: Style.current.fontHexRegular.name
         anchors.top: typeText.bottom
         anchors.topMargin: marginBetweenInputs
     }
@@ -112,10 +112,10 @@ ModalPopup {
         StyledButton {
             anchors.top: parent.top
             anchors.right: saveBtn.left
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             label: qsTr("Delete account")
-            btnColor: Theme.white
-            textColor: Theme.red
+            btnColor: Style.current.white
+            textColor: Style.current.red
 
             MessageDialog {
                 id: deleteError
@@ -154,7 +154,7 @@ ModalPopup {
             id: saveBtn
             anchors.top: parent.top
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             label: qsTr("Save changes")
 
             disabled: accountNameInput.text === ""

--- a/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
+++ b/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
@@ -57,9 +57,9 @@ ModalPopup {
         StyledButton {
             id: addBtn
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             label: qsTr("Add")
 
             disabled: addressInput.text === "" || nameInput.text === "" || symbolInput.text === "" || decimalsInput.text === ""

--- a/ui/app/AppLayouts/Wallet/AssetsTab.qml
+++ b/ui/app/AppLayouts/Wallet/AssetsTab.qml
@@ -32,10 +32,10 @@ Item {
                 id: assetSymbol
                 text: symbol
                 anchors.left: assetInfoImage.right
-                anchors.leftMargin: Theme.smallPadding
+                anchors.leftMargin: Style.current.smallPadding
                 anchors.top: assetInfoImage.top
                 anchors.topMargin: 0
-                color: Theme.black
+                color: Style.current.black
                 font.pixelSize: 15
             }
             StyledText {
@@ -44,8 +44,8 @@ Item {
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 0
                 anchors.left: assetInfoImage.right
-                anchors.leftMargin: Theme.smallPadding
-                color: Theme.darkGrey
+                anchors.leftMargin: Style.current.smallPadding
+                color: Style.current.darkGrey
                 font.pixelSize: 15
             }
             StyledText {
@@ -58,7 +58,7 @@ Item {
             }
             StyledText {
                 id: assetFiatValue
-                color: Theme.darkGrey
+                color: Style.current.darkGrey
                 text: fiatValue
                 anchors.right: parent.right
                 anchors.rightMargin: 0

--- a/ui/app/AppLayouts/Wallet/CollectiblesTab.qml
+++ b/ui/app/AppLayouts/Wallet/CollectiblesTab.qml
@@ -34,17 +34,17 @@ Item {
                 text: name
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: collectibleImage.right
-                anchors.leftMargin: Theme.padding
+                anchors.leftMargin: Style.current.padding
                 font.pixelSize: 15
             }
 
             StyledText {
                 id: collectibleIdText
                 text: collectibleId
-                anchors.leftMargin: Theme.padding
+                anchors.leftMargin: Style.current.padding
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: collectibleName.right
-                color: Theme.darkGrey
+                color: Style.current.darkGrey
                 font.pixelSize: 15
             }
         }
@@ -62,8 +62,8 @@ Item {
 
     ListView {
         id: assetListView
-        spacing: Theme.smallPadding
-        anchors.topMargin: Theme.bigPadding
+        spacing: Style.current.smallPadding
+        anchors.topMargin: Style.current.bigPadding
         anchors.fill: parent
 //        model: exampleModel
         model: walletModel.collectibles

--- a/ui/app/AppLayouts/Wallet/HistoryTab.qml
+++ b/ui/app/AppLayouts/Wallet/HistoryTab.qml
@@ -79,9 +79,9 @@ Item {
           StyledText {
             id: transactionValue
             anchors.left: transferIcon.right
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.top: parent.top
-            anchors.topMargin: Theme.bigPadding
+            anchors.topMargin: Style.current.bigPadding
             font.pixelSize: 15
             text: value + " " + transactionListItem.symbol
           }
@@ -90,13 +90,13 @@ Item {
         Item {
           anchors.right: timeInfo.left
           anchors.top: parent.top
-          anchors.topMargin: Theme.bigPadding
+          anchors.topMargin: Style.current.bigPadding
           width: children[0].width + children[1].width
 
           StyledText {
               text: to != walletModel.currentAccount.address ? "To " : "From "
               anchors.right: addressValue.left
-              color: Theme.darkGrey
+              color: Style.current.darkGrey
               anchors.top: parent.top
               font.pixelSize: 15
               font.strikeout: false
@@ -104,7 +104,7 @@ Item {
 
           StyledText {
               id: addressValue
-              font.family: Theme.fontHexRegular.name
+              font.family: Style.current.fontHexRegular.name
               text: to
               width: 100
               elide: Text.ElideMiddle
@@ -118,14 +118,14 @@ Item {
           id: timeInfo
           anchors.right: parent.right
           anchors.top: parent.top
-          anchors.topMargin: Theme.bigPadding
+          anchors.topMargin: Style.current.bigPadding
           width: children[0].width + children[1].width + children[2].width
 
           StyledText {
               text: "• "
               font.weight: Font.Bold
               anchors.right: timeIndicator.left
-              color: Theme.darkGrey
+              color: Style.current.darkGrey
               anchors.top: parent.top
               font.pixelSize: 15
           }
@@ -134,7 +134,7 @@ Item {
               id: timeIndicator
               text: "At "
               anchors.right: timeValue.left
-              color: Theme.darkGrey
+              color: Style.current.darkGrey
               anchors.top: parent.top
               font.pixelSize: 15
               font.strikeout: false

--- a/ui/app/AppLayouts/Wallet/LeftTab.qml
+++ b/ui/app/AppLayouts/Wallet/LeftTab.qml
@@ -23,8 +23,8 @@ Item {
         anchors.leftMargin: 0
         anchors.right: parent.right
         anchors.rightMargin: 0
-        height: walletValueTextContainer.y + walletValueTextContainer.height + Theme.padding
-        color: Theme.white
+        height: walletValueTextContainer.y + walletValueTextContainer.height + Style.current.padding
+        color: Style.current.white
         z: 1
         border.width: 0
 
@@ -34,7 +34,7 @@ Item {
             y: 16
             text: qsTr("Wallet")
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.horizontalCenter: parent.horizontalCenter
             font.weight: Font.Bold
             font.pixelSize: 17
@@ -45,9 +45,9 @@ Item {
             x: 16
             y: 52
             anchors.left: parent.left
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             anchors.top: title.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             height: walletAmountValue.height + totalValue.height
 
             StyledTextEdit {
@@ -65,7 +65,7 @@ Item {
 
             StyledText {
                 id: totalValue
-                color: Theme.darkGrey
+                color: Style.current.darkGrey
                 text: "Total value"
                 anchors.left: walletAmountValue.left
                 anchors.leftMargin: 0
@@ -80,7 +80,7 @@ Item {
             anchors.topMargin: 3
             anchors.top: walletValueTextContainer.top
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
 
         }
     }
@@ -93,65 +93,65 @@ Item {
 
             id: rectangle
             height: 64
-            color: selected ? Theme.blue : Theme.transparent
-            radius: Theme.radius
+            color: selected ? Style.current.blue : Style.current.transparent
+            radius: Style.current.radius
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             anchors.left: parent.left
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
 
             SVGImage {
                 id: walletIcon
                 width: 12
                 height: 12
                 anchors.top: parent.top
-                anchors.topMargin: Theme.smallPadding
+                anchors.topMargin: Style.current.smallPadding
                 anchors.left: parent.left
-                anchors.leftMargin: Theme.padding
+                anchors.leftMargin: Style.current.padding
                 source: "../../img/walletIcon.svg"
             }
             ColorOverlay {
                 anchors.fill: walletIcon
                 source: walletIcon
-                color: selected || !iconColor ? Theme.white : iconColor  // change image color
+                color: selected || !iconColor ? Style.current.white : iconColor  // change image color
             }
             StyledText {
                 id: walletName
                 text: name
                 anchors.top: parent.top
-                anchors.topMargin: Theme.smallPadding
+                anchors.topMargin: Style.current.smallPadding
                 anchors.left: walletIcon.right
                 anchors.leftMargin: 10
                 font.pixelSize: 15
                 font.weight: Font.Medium
-                color: selected ? Theme.white : Theme.black
+                color: selected ? Style.current.white : Style.current.black
             }
             StyledText {
                 id: walletAddress
-                font.family: Theme.fontHexRegular.name
+                font.family: Style.current.fontHexRegular.name
                 text: address
                 anchors.right: parent.right
                 anchors.rightMargin: parent.width/2
                 elide: Text.ElideMiddle
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: Theme.smallPadding
+                anchors.bottomMargin: Style.current.smallPadding
                 anchors.left: walletName.left
                 anchors.leftMargin: 0
                 font.pixelSize: 15
                 font.weight: Font.Medium
-                color: selected ? Theme.white : Theme.darkGrey
+                color: selected ? Style.current.white : Style.current.darkGrey
                 opacity: selected ? 0.7 : 1
             }
             StyledText {
                 id: walletBalance
                 text: balance
                 anchors.top: parent.top
-                anchors.topMargin: Theme.smallPadding
+                anchors.topMargin: Style.current.smallPadding
                 anchors.right: parent.right
-                anchors.rightMargin: Theme.padding
+                anchors.rightMargin: Style.current.padding
                 font.pixelSize: 15
                 font.weight: Font.Medium
-                color: selected ? Theme.white : Theme.black
+                color: selected ? Style.current.white : Style.current.black
             }
             MouseArea {
                 anchors.fill: parent

--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -52,7 +52,7 @@ ModalPopup {
     footer: StyledButton {
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: qsTr("Send")
 
         onClicked: {

--- a/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
+++ b/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
@@ -29,8 +29,8 @@ Item {
         width: 480
         height: 510
         background: Rectangle {
-            color: Theme.white
-            radius: Theme.radius
+            color: Style.current.white
+            radius: Style.current.radius
         }
         padding: 0
         contentItem: SetCurrencyModalContent {

--- a/ui/app/AppLayouts/Wallet/TokenSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/TokenSettingsModal.qml
@@ -15,7 +15,7 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: qsTr("Add custom token")
         anchors.top: parent.top
         onClicked: {

--- a/ui/app/AppLayouts/Wallet/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/WalletHeader.qml
@@ -34,7 +34,7 @@ Item {
         id: separatorDot
         width: 8
         height: 8
-        color: Theme.blue
+        color: Style.current.blue
         anchors.top: title.verticalCenter
         anchors.topMargin: -3
         anchors.left: title.right
@@ -54,7 +54,7 @@ Item {
     StyledText {
         id: walletAddress
         text: currentAccount.address
-        font.family: Theme.fontHexRegular.name
+        font.family: Style.current.fontHexRegular.name
         elide: Text.ElideMiddle
         anchors.right: title.right
         anchors.rightMargin: 0
@@ -63,7 +63,7 @@ Item {
         anchors.left: title.left
         anchors.leftMargin: 0
         font.pixelSize: 13
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
 
     SendModal{
@@ -117,13 +117,13 @@ Item {
                 anchors.left: sendImg.right
                 anchors.leftMargin: walletMenu.btnMargin
                 font.pixelSize: 13
-                color: Theme.blue
+                color: Style.current.blue
             }
             MouseArea {
-                anchors.rightMargin: -Theme.smallPadding
-                anchors.leftMargin: -Theme.smallPadding
-                anchors.bottomMargin: -Theme.smallPadding
-                anchors.topMargin: -Theme.smallPadding
+                anchors.rightMargin: -Style.current.smallPadding
+                anchors.leftMargin: -Style.current.smallPadding
+                anchors.bottomMargin: -Style.current.smallPadding
+                anchors.topMargin: -Style.current.smallPadding
                 anchors.fill: parent
                 onClicked: sendModal.open()
                 cursorShape: Qt.PointingHandCursor
@@ -150,7 +150,7 @@ Item {
                 anchors.left: receiveImg.right
                 anchors.leftMargin: walletMenu.btnMargin
                 font.pixelSize: 13
-                color: Theme.blue
+                color: Style.current.blue
             }
         }
         Item {
@@ -168,10 +168,10 @@ Item {
             }
 
             MouseArea {
-                anchors.rightMargin: -Theme.smallPadding
-                anchors.leftMargin: -Theme.smallPadding
-                anchors.bottomMargin: -Theme.smallPadding
-                anchors.topMargin: -Theme.smallPadding
+                anchors.rightMargin: -Style.current.smallPadding
+                anchors.leftMargin: -Style.current.smallPadding
+                anchors.bottomMargin: -Style.current.smallPadding
+                anchors.topMargin: -Style.current.smallPadding
                 anchors.fill: parent
                 acceptedButtons: Qt.LeftButton | Qt.RightButton
                 cursorShape: Qt.PointingHandCursor

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -19,9 +19,9 @@ SplitView {
 
     LeftTab {
         id: leftTab
-        SplitView.preferredWidth: Theme.leftTabPrefferedSize
-        SplitView.minimumWidth: Theme.leftTabMinimumWidth
-        SplitView.maximumWidth: Theme.leftTabMaximumWidth
+        SplitView.preferredWidth: Style.current.leftTabPrefferedSize
+        SplitView.minimumWidth: Style.current.leftTabMinimumWidth
+        SplitView.maximumWidth: Style.current.leftTabMaximumWidth
     }
 
     Item {
@@ -59,11 +59,11 @@ SplitView {
                 TabBar {
                     id: walletTabBar
                     anchors.right: parent.right
-                    anchors.rightMargin: Theme.bigPadding
+                    anchors.rightMargin: Style.current.bigPadding
                     anchors.left: parent.left
-                    anchors.leftMargin: Theme.bigPadding
+                    anchors.leftMargin: Style.current.bigPadding
                     anchors.top: parent.top
-                    anchors.topMargin: Theme.padding
+                    anchors.topMargin: Style.current.padding
                     height: assetBtn.height
 
                     StatusTabButton {
@@ -92,13 +92,13 @@ SplitView {
 
                 StackLayout {
                     id: stackLayout
-                    anchors.rightMargin: Theme.bigPadding
-                    anchors.leftMargin: Theme.bigPadding
+                    anchors.rightMargin: Style.current.bigPadding
+                    anchors.leftMargin: Style.current.bigPadding
                     anchors.top: walletTabBar.bottom
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
-                    anchors.topMargin: Theme.bigPadding
+                    anchors.topMargin: Style.current.bigPadding
                     currentIndex: walletTabBar.currentIndex
 
                     AssetsTab {

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
@@ -102,7 +102,7 @@ ModalPopup {
     footer: StyledButton {
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: loading ? qsTr("Loading...") : qsTr("Add account >")
 
         disabled: loading || passwordInput.text === "" || accountNameInput.text === "" || accountPKeyInput.text === ""

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
@@ -103,7 +103,7 @@ ModalPopup {
     footer: StyledButton {
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: loading ? qsTr("Loading...") : qsTr("Add account >")
 
         disabled: loading || passwordInput.text === "" || accountNameInput.text === "" || accountSeedInput.text === ""

--- a/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
@@ -81,7 +81,7 @@ ModalPopup {
     footer: StyledButton {
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: loading ? qsTr("Loading...") : qsTr("Add account >")
 
         disabled: loading || addressInput.text === "" || accountNameInput.text === ""

--- a/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
@@ -81,7 +81,7 @@ ModalPopup {
     footer: StyledButton {
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: loading ? qsTr("Loading...") : qsTr("Add account >")
 
         disabled: loading || passwordInput.text === "" || accountNameInput.text === ""

--- a/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
@@ -112,7 +112,7 @@ Item {
         icon:  "../../../img/tokens/" + selectedAssetSymbol.toUpperCase() + ".png"
         label: qsTr("Select the asset")
         anchors.top: txtAmount.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         selectedText: selectedAssetName
         selectOptions: sendModalContent.assets.map(function (asset, index) {
             return {
@@ -128,7 +128,7 @@ Item {
         id: currentBalanceText
         text: qsTr("Balance: %1").arg(selectedAccountValue)
         font.pixelSize: 13
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         anchors.top: assetTypeSelect.top
         anchors.topMargin: 0
         anchors.right: assetTypeSelect.right
@@ -143,7 +143,7 @@ Item {
         iconColor: selectedAccountIconColor
         label: qsTr("From account")
         anchors.top: assetTypeSelect.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         selectedText: selectedAccountName
         selectOptions: sendModalContent.accounts.map(function (account, index) {
             return {
@@ -158,14 +158,14 @@ Item {
     StyledText {
         id: textSelectAccountAddress
         text: selectedAccountAddress
-        font.family: Theme.fontHexRegular.name
+        font.family: Style.current.fontHexRegular.name
         anchors.right: parent.right
         anchors.left: parent.left
         anchors.leftMargin: 2
         elide: Text.ElideMiddle
         anchors.top: txtFrom.bottom
         font.pixelSize: 12
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
 
     Input {
@@ -173,7 +173,7 @@ Item {
         label: qsTr("Recipient")
         placeholderText: qsTr("Send to")
         anchors.top: textSelectAccountAddress.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         validationError: toValidationError
     }
 
@@ -182,7 +182,7 @@ Item {
         label: qsTr("Password")
         placeholderText: qsTr("Enter Password")
         anchors.top: txtTo.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         textField.echoMode: TextInput.Password
         validationError: passwordValidationError
     }

--- a/ui/app/AppLayouts/Wallet/components/SetCurrencyModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SetCurrencyModalContent.qml
@@ -52,9 +52,9 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: 32
         anchors.top: headerSeparator.top
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         anchors.bottom: footerSeparator.top
-        anchors.bottomMargin: Theme.padding
+        anchors.bottomMargin: Style.current.padding
         anchors.left: parent.left
         anchors.leftMargin: 32
 
@@ -103,10 +103,10 @@ Item {
 
     StyledButton {
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: "Save"
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Theme.padding
+        anchors.bottomMargin: Style.current.padding
         onClicked: {
             console.log("TODO: apply all accounts")
             popup.close()

--- a/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
@@ -23,7 +23,7 @@ Item {
         anchors.bottom: parent.bottom
         spacing: 0
         id: tokenListView
-        anchors.topMargin: Theme.smallPadding
+        anchors.topMargin: Style.current.smallPadding
         model: Tokens {}
         ScrollBar.vertical: ScrollBar { active: true }
 
@@ -33,12 +33,12 @@ Item {
                 id: tokenContainer
                 anchors.right: parent.right
                 anchors.left: parent.left
-                anchors.leftMargin: Theme.smallPadding
+                anchors.leftMargin: Style.current.smallPadding
                 width: parent.width
                 property bool isVisible: symbol && (searchBox.text == "" || name.toLowerCase().includes(searchBox.text.toLowerCase()) || symbol.toLowerCase().includes(searchBox.text.toLowerCase()))
 
                 visible: isVisible
-                height: isVisible ? 40 + Theme.smallPadding : 0
+                height: isVisible ? 40 + Style.current.smallPadding : 0
 
                 Image {
                     id: assetInfoImage
@@ -54,10 +54,10 @@ Item {
                     id: assetSymbol
                     text: symbol
                     anchors.left: assetInfoImage.right
-                    anchors.leftMargin: Theme.smallPadding
+                    anchors.leftMargin: Style.current.smallPadding
                     anchors.top: assetInfoImage.top
                     anchors.topMargin: 0
-                    color: Theme.black
+                    color: Style.current.black
                     font.pixelSize: 15
                 }
                 StyledText {
@@ -66,15 +66,15 @@ Item {
                     anchors.bottom: assetInfoImage.bottom
                     anchors.bottomMargin: 0
                     anchors.left: assetInfoImage.right
-                    anchors.leftMargin: Theme.smallPadding
-                    color: Theme.darkGrey
+                    anchors.leftMargin: Style.current.smallPadding
+                    color: Style.current.darkGrey
                     font.pixelSize: 15
                 }
                 CheckBox  {
                     id: assetCheck
                     checked: walletModel.hasAsset("0x123", symbol)
                     anchors.right: parent.right
-                    anchors.rightMargin: Theme.smallPadding
+                    anchors.rightMargin: Style.current.smallPadding
                     onClicked: walletModel.toggleAsset(symbol, assetCheck.checked, address, name, decimals, "eeeeee")
                 }
             }

--- a/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
@@ -10,12 +10,12 @@ ModalPopup {
   Item {
     id: confirmations
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     anchors.top: parent.top
-    anchors.topMargin: Theme.smallPadding
+    anchors.topMargin: Style.current.smallPadding
     anchors.right: parent.right
-    anchors.rightMargin: Theme.smallPadding
-    height: children[0].height + children[1].height + Theme.smallPadding
+    anchors.rightMargin: Style.current.smallPadding
+    height: children[0].height + children[1].height + Style.current.smallPadding
 
     StyledText {
       id: confirmationsCount
@@ -28,28 +28,28 @@ ModalPopup {
       text: qsTr("When the transaction has 12 confirmations you can consider it settled.")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
       anchors.top: confirmationsCount.bottom
-      anchors.topMargin: Theme.smallPadding
+      anchors.topMargin: Style.current.smallPadding
     }
   }
 
   Separator {
     id: separator
     anchors.top: confirmations.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: -Theme.padding
+    anchors.leftMargin: -Style.current.padding
     anchors.right: parent.right
-    anchors.rightMargin: -Theme.padding
+    anchors.rightMargin: -Style.current.padding
   }
 
   Item {
     id: block
     anchors.top: separator.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -57,7 +57,7 @@ ModalPopup {
       text: qsTr("Block")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -65,16 +65,16 @@ ModalPopup {
       text: blockNumber
       font.pixelSize: 14
       anchors.left: labelBlock.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: hash
     anchors.top: block.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -82,27 +82,27 @@ ModalPopup {
       text: qsTr("Hash")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
       id: valueHash
       text: blockHash
-      font.family: Theme.fontHexRegular.name
+      font.family: Style.current.fontHexRegular.name
       width: 160
       elide: Text.ElideMiddle
       font.pixelSize: 14
       anchors.left: labelHash.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: from
     anchors.top: hash.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -110,27 +110,27 @@ ModalPopup {
       text: qsTr("From")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
       id: valueFrom
       text: fromAddress
-      font.family: Theme.fontHexRegular.name
+      font.family: Style.current.fontHexRegular.name
       width: 160
       elide: Text.ElideMiddle
       font.pixelSize: 14
       anchors.left: labelFrom.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: toItem
     anchors.top: from.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -138,7 +138,7 @@ ModalPopup {
       text: qsTr("To")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -148,16 +148,16 @@ ModalPopup {
       elide: Text.ElideMiddle
       font.pixelSize: 14
       anchors.left: labelTo.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: gasLimitItem
     anchors.top: toItem.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -165,7 +165,7 @@ ModalPopup {
       text: qsTr("Gas limit")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -173,16 +173,16 @@ ModalPopup {
       text: gasLimit
       font.pixelSize: 14
       anchors.left: labelGasLimit.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: gasPriceItem
     anchors.top: gasLimitItem.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -190,7 +190,7 @@ ModalPopup {
       text: qsTr("Gas price")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -198,16 +198,16 @@ ModalPopup {
       text: gasPrice
       font.pixelSize: 14
       anchors.left: labelGasPrice.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: gasUsedItem
     anchors.top: gasPriceItem.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -215,7 +215,7 @@ ModalPopup {
       text: qsTr("Gas used")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -223,16 +223,16 @@ ModalPopup {
       text: gasUsed
       font.pixelSize: 14
       anchors.left: labelGasUsed.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 
   Item {
     id: nonceItem
     anchors.top: gasUsedItem.bottom
-    anchors.topMargin: Theme.padding
+    anchors.topMargin: Style.current.padding
     anchors.left: parent.left
-    anchors.leftMargin: Theme.smallPadding
+    anchors.leftMargin: Style.current.smallPadding
     height: children[0].height
 
     StyledText {
@@ -240,7 +240,7 @@ ModalPopup {
       text: qsTr("Nonce")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Theme.darkGrey
+      color: Style.current.darkGrey
     }
 
     StyledText {
@@ -248,7 +248,7 @@ ModalPopup {
       text: nonce
       font.pixelSize: 14
       anchors.left: labelNonce.right
-      anchors.leftMargin: Theme.padding
+      anchors.leftMargin: Style.current.padding
     }
   }
 }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -28,7 +28,7 @@ RowLayout {
         spacing: 5
         background: Rectangle {
             color: "#00000000"
-            border.color: Theme.grey
+            border.color: Style.current.grey
         }
 
         TabButton {
@@ -41,7 +41,7 @@ RowLayout {
             transformOrigin: Item.Center
             anchors.horizontalCenter: parent.horizontalCenter
             background: Rectangle {
-                color: Theme.lightBlue
+                color: Style.current.lightBlue
                 opacity: parent.checked ? 1 : 0
                 radius: 50
             }
@@ -68,7 +68,7 @@ RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: chatBtn.top
             background: Rectangle {
-                color: Theme.lightBlue
+                color: Style.current.lightBlue
                 opacity: parent.checked ? 1 : 0
                 radius: 50
             }
@@ -95,7 +95,7 @@ RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: walletBtn.top
             background: Rectangle {
-                color: Theme.lightBlue
+                color: Style.current.lightBlue
                 opacity: parent.checked ? 1 : 0
                 radius: 50
             }
@@ -120,7 +120,7 @@ RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: browserBtn.top
             background: Rectangle {
-                color: Theme.lightBlue
+                color: Style.current.lightBlue
                 opacity: parent.checked ? 1 : 0
                 radius: 50
             }
@@ -147,7 +147,7 @@ RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: profileBtn.top
             background: Rectangle {
-                color: Theme.lightBlue
+                color: Style.current.lightBlue
                 opacity: parent.checked ? 1 : 0
                 radius: 50
             }

--- a/ui/imports/Style.qml
+++ b/ui/imports/Style.qml
@@ -5,5 +5,15 @@ import "./Themes"
 
 QtObject {
     property Theme current: lightTheme
-    property Theme lightTheme: LightTheme { }
+    property Theme lightTheme: LightTheme {}
+    property Theme darkTheme: DarkTheme {}
+
+    property var changeTheme: function (theme) {
+        switch (theme) {
+            case "light": current = lightTheme; break;
+            case "dark": current = darkTheme; break;
+            default: current = lightTheme; console.log('Unknown theme. Valid themes are "light" and "dark"')
+        }
+
+    }
 }

--- a/ui/imports/Style.qml
+++ b/ui/imports/Style.qml
@@ -1,0 +1,9 @@
+pragma Singleton
+
+import QtQuick 2.13
+import "./Themes"
+
+QtObject {
+    property Theme current: lightTheme
+    property Theme lightTheme: LightTheme { }
+}

--- a/ui/imports/Theme.qml
+++ b/ui/imports/Theme.qml
@@ -3,15 +3,10 @@ pragma Singleton
 import QtQuick 2.13
 
 QtObject {
-    property QtObject fontMedium: FontLoader { id: _fontMedium; source: "../fonts/Inter/Inter-Medium.otf"; }
-    property QtObject fontBold: FontLoader { id: _fontBold; source: "../fonts/Inter/Inter-Bold.otf"; }
-    property QtObject fontLight: FontLoader { id: _fontLight; source: "../fonts/Inter/Inter-Light.otf"; }
-    property QtObject fontRegular: FontLoader { id: _fontRegular; source: "../fonts/Inter/Inter-Regular.otf"; }
-
-    property QtObject fontHexMedium: FontLoader { id: _fontHexMedium; source: "../fonts/InterStatus/InterStatus-Medium.otf"; }
-    property QtObject fontHexBold: FontLoader { id: _fontHexBold; source: "../fonts/InterStatus/InterStatus-Bold.otf"; }
-    property QtObject fontHexLight: FontLoader { id: _fontHexLight; source: "../fonts/InterStatus/InterStatus-Light.otf"; }
-    property QtObject fontHexRegular: FontLoader { id: _fontHexRegular; source: "../fonts/InterStatus/InterStatus-Regular.otf"; }
+    property QtObject fontMedium: FontLoader { id: _fontMedium; source: "../fonts/InterStatus/InterStatus-Medium.otf"; }
+    property QtObject fontBold: FontLoader { id: _fontBold; source: "../fonts/InterStatus/InterStatus-Bold.otf"; }
+    property QtObject fontLight: FontLoader { id: _fontLight; source: "../fonts/InterStatus/InterStatus-Light.otf"; }
+    property QtObject fontRegular: FontLoader { id: _fontRegular; source: "../fonts/InterStatus/InterStatus-Regular.otf"; }
     
 
     readonly property color white: "#FFFFFF"

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.13
+import "."
+
+Theme {
+    property color white: "#000000"
+    property color white2: "#FCFCFC"
+    property color black: "#000000"
+    property color grey: "#EEF2F5"
+    property color lightBlue: "#ECEFFC"
+    property color blue: "#4360DF"
+    property color transparent: "#00000000"
+    property color darkGrey: "#939BA1"
+    property color lightBlueText: "#8f9fec"
+    property color darkBlue: "#3c55c9"
+    property color darkBlueBtn: "#5a70dd"
+    property color red: "#FF2D55"
+}

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.13
+import "."
+
+Theme {
+    property color white: "#FFFFFF"
+    property color white2: "#FCFCFC"
+    property color black: "#000000"
+    property color grey: "#EEF2F5"
+    property color lightBlue: "#ECEFFC"
+    property color blue: "#4360DF"
+    property color transparent: "#00000000"
+    property color darkGrey: "#939BA1"
+    property color lightBlueText: "#8f9fec"
+    property color darkBlue: "#3c55c9"
+    property color darkBlueBtn: "#5a70dd"
+    property color red: "#FF2D55"
+}

--- a/ui/imports/Themes/Theme.qml
+++ b/ui/imports/Themes/Theme.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.13
+
+QtObject {
+    property QtObject fontMedium: FontLoader { id: _fontMedium; source: "../../fonts/Inter/Inter-Medium.otf"; }
+    property QtObject fontBold: FontLoader { id: _fontBold; source: "../../fonts/Inter/Inter-Bold.otf"; }
+    property QtObject fontLight: FontLoader { id: _fontLight; source: "../../fonts/Inter/Inter-Light.otf"; }
+    property QtObject fontRegular: FontLoader { id: _fontRegular; source: "../../fonts/Inter/Inter-Regular.otf"; }
+
+    property QtObject fontHexMedium: FontLoader { id: _fontHexMedium; source: "../../fonts/InterStatus/InterStatus-Medium.otf"; }
+    property QtObject fontHexBold: FontLoader { id: _fontHexBold; source: "../../fonts/InterStatus/InterStatus-Bold.otf"; }
+    property QtObject fontHexLight: FontLoader { id: _fontHexLight; source: "../../fonts/InterStatus/InterStatus-Light.otf"; }
+    property QtObject fontHexRegular: FontLoader { id: _fontHexRegular; source: "../../fonts/InterStatus/InterStatus-Regular.otf"; }
+
+    property color white
+    property color white2
+    property color black
+    property color grey
+    property color lightBlue
+    property color blue
+    property color transparent
+    property color darkGrey
+    property color lightBlueText
+    property color darkBlue
+    property color darkBlueBtn
+    property color red
+
+    property int xlPadding: 32
+    property int bigPadding: 24
+    property int padding: 16
+    property int smallPadding: 10
+    property int radius: 8
+
+    property int leftTabPrefferedSize: 340
+    property int leftTabMinimumWidth: 300
+    property int leftTabMaximumWidth: 500
+}

--- a/ui/imports/Themes/qmldir
+++ b/ui/imports/Themes/qmldir
@@ -1,2 +1,4 @@
 Theme 1.0 ./Theme.qml
 LightTheme 1.0 ./LightTheme.qml
+DarkTheme 1.0 ./DarkTheme.qml
+

--- a/ui/imports/Themes/qmldir
+++ b/ui/imports/Themes/qmldir
@@ -1,0 +1,2 @@
+Theme 1.0 ./Theme.qml
+LightTheme 1.0 ./LightTheme.qml

--- a/ui/imports/qmldir
+++ b/ui/imports/qmldir
@@ -1,6 +1,5 @@
-module Theme
-singleton Theme 1.0 ./Theme.qml
+module Style
+singleton Style 1.0 ./Style.qml
 singleton Constants 1.0 ./Constants.qml
 singleton Utils 1.0 ./Utils.qml
 singleton Emoji 1.0 ./Emoji.qml
-

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -16,6 +16,7 @@ ApplicationWindow {
     id: applicationWindow
     width: 1232
     height: 770
+    color: Style.current.white
     title: {
         // Set application settings
         Qt.application.name = qsTr("Nim Status Client")
@@ -214,3 +215,9 @@ ApplicationWindow {
         }
     }
 }
+
+/*##^##
+Designer {
+    D{i:0;formeditorZoom:0.5}
+}
+##^##*/

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -35,8 +35,8 @@ TRANSLATIONS = status_en.ts \
                status_es.ts
 
 RESOURCES += \
-    imports/Theme.qml \
     imports/Constants.qml \
+    imports/Style.qml \
     main.qml
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
@@ -169,6 +169,9 @@ DISTFILES += \
     app/img/walletActive.svg \
     app/qmldir \
     imports/Emoji.qml \
+    imports/Themes/LightTheme.qml \
+    imports/Themes/Theme.qml \
+    imports/Themes/qmldir \
     imports/Utils.qml \
     imports/qmldir \
     onboarding/CreatePasswordModal.qml \

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -169,6 +169,7 @@ DISTFILES += \
     app/img/walletActive.svg \
     app/qmldir \
     imports/Emoji.qml \
+    imports/Themes/DarkTheme.qml \
     imports/Themes/LightTheme.qml \
     imports/Themes/Theme.qml \
     imports/Themes/qmldir \

--- a/ui/onboarding/CreatePasswordModal.qml
+++ b/ui/onboarding/CreatePasswordModal.qml
@@ -63,7 +63,7 @@ ModalPopup {
         anchors.right: firstPasswordField.right
         anchors.left: firstPasswordField.left
         anchors.top: firstPasswordField.bottom
-        anchors.topMargin: Theme.xlPadding
+        anchors.topMargin: Style.current.xlPadding
         placeholderText: qsTr("Confirm password…")
         textField.echoMode: TextInput.Password
         validationError: popup.repeatPasswordValidationError
@@ -76,13 +76,13 @@ ModalPopup {
         text: qsTr("At least 6 characters. You will use this password to unlock status on this device & sign transactions.")
         wrapMode: Text.WordWrap
         anchors.right: parent.right
-        anchors.rightMargin: Theme.xlPadding
+        anchors.rightMargin: Style.current.xlPadding
         anchors.left: parent.left
-        anchors.leftMargin: Theme.xlPadding
+        anchors.leftMargin: Style.current.xlPadding
         horizontalAlignment: Text.AlignHCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         font.pixelSize: 12
     }
 
@@ -96,9 +96,9 @@ ModalPopup {
             id: loadingImg
             visible: loading
             anchors.top: submitBtn.top
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.right: submitBtn.left
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             source: "../app/img/settings.svg"
             width: 20
             height: 20
@@ -116,9 +116,9 @@ ModalPopup {
         StyledButton {
             id: submitBtn
             anchors.bottom: parent.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             label: loading ? qsTr("Logging in...") : qsTr("Create password")
 
             disabled: firstPasswordField.text === "" || repeatPasswordField.text === "" || loading

--- a/ui/onboarding/EnterSeedPhraseModal.qml
+++ b/ui/onboarding/EnterSeedPhraseModal.qml
@@ -37,21 +37,21 @@ ModalPopup {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         font.pixelSize: 12
     }
 
     footer: Button {
         id: submitBtn
         anchors.bottom: parent.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         width: 44
         height: 44
         background: Rectangle {
             radius: 50
-            color: Theme.lightBlue
+            color: Style.current.lightBlue
         }
 
         SVGImage {

--- a/ui/onboarding/GenKeyModal.qml
+++ b/ui/onboarding/GenKeyModal.qml
@@ -28,14 +28,14 @@ ModalPopup {
     footer: Button {
         id: submitBtn
         anchors.bottom: parent.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         width: 44
         height: 44
         background: Rectangle {
             radius: 50
-            color: Theme.lightBlue
+            color: Style.current.lightBlue
         }
 
         SVGImage {

--- a/ui/onboarding/Intro.qml
+++ b/ui/onboarding/Intro.qml
@@ -82,7 +82,7 @@ RowLayout {
             font.letterSpacing: 0.1
             width: 700
             wrapMode: Text.Wrap
-            color: Theme.black
+            color: Style.current.black
         }
 
         CheckBox {
@@ -96,7 +96,7 @@ RowLayout {
         StyledButton {
             id: btnGetStarted
             enabled: warningCheckBox.checked
-            btnColor: this.enabled ? Theme.lightBlue : "lightgrey"
+            btnColor: this.enabled ? Style.current.lightBlue : "lightgrey"
             label: "Get Started"
             anchors.top: warningCheckBox.bottom
             anchors.topMargin: 5

--- a/ui/onboarding/InvalidSeedPhraseModal.qml
+++ b/ui/onboarding/InvalidSeedPhraseModal.qml
@@ -18,7 +18,7 @@ ModalPopup {
   
   footer: StyledButton {
       anchors.right: parent.right
-      anchors.rightMargin: Theme.smallPadding
+      anchors.rightMargin: Style.current.smallPadding
       label: qsTr("Cancel")
       anchors.bottom: parent.bottom
       onClicked: {

--- a/ui/onboarding/KeysMain.qml
+++ b/ui/onboarding/KeysMain.qml
@@ -16,7 +16,7 @@ Page {
             const children = this.children
             Object.keys(children).forEach(function (key) {
                 const child = children[key]
-                h += child.height + Theme.padding
+                h += child.height + Style.current.padding
             })
             return h
         }
@@ -35,7 +35,7 @@ Page {
         StyledText {
             id: txtTitle1
             text: qsTr("Get your keys")
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             font.bold: true
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: keysImg.bottom
@@ -45,14 +45,14 @@ Page {
 
         StyledText {
             id: txtDesc1
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             text: qsTr("A set of keys controls your account. Your keys live on your device, so only you can use them.")
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             anchors.right: parent.right
             anchors.left: parent.left
             anchors.top: txtTitle1.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             font.pixelSize: 15
         }
 
@@ -70,7 +70,7 @@ Page {
             id: btnExistingKey
             label: qsTr("Access existing key")
             anchors.top: btnGenKey.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.horizontalCenter: parent.horizontalCenter
             height: 44
             background: Rectangle {color: "transparent"}

--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -82,7 +82,7 @@ Item {
             anchors.leftMargin: 4
             anchors.verticalCenter: usernameText.verticalCenter
 
-            color: isHovered ? Theme.grey : Theme.transparent
+            color: isHovered ? Style.current.grey : Style.current.transparent
 
             radius: 4
 
@@ -98,7 +98,7 @@ Item {
             ColorOverlay {
                 anchors.fill: caretImg
                 source: caretImg
-                color: Theme.darkGrey
+                color: Style.current.darkGrey
             }
             MouseArea {
                 hoverEnabled: true
@@ -123,9 +123,9 @@ Item {
         StyledText {
             id: addressText
             width: 90
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
             text: loginModel.currentAccount.address
-            font.family: Theme.fontHexRegular.name
+            font.family: Style.current.fontHexRegular.name
             elide: Text.ElideMiddle
             font.pixelSize: 15
             anchors.top: usernameText.bottom
@@ -136,7 +136,7 @@ Item {
         Input {
             id: txtPassword
             anchors.top: addressText.bottom
-            anchors.topMargin: Theme.padding * 2
+            anchors.topMargin: Style.current.padding * 2
             placeholderText: "Enter password"
             textField.echoMode: TextInput.Password
             textField.focus: true
@@ -151,7 +151,7 @@ Item {
             width: 40
             height: 40
             anchors.left: txtPassword.right
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             anchors.verticalCenter: txtPassword.verticalCenter
             onClicked: {
                 if (loading) {
@@ -171,7 +171,7 @@ Item {
                 rotation: 90
             }
             background: Rectangle {
-                color: Theme.blue
+                color: Style.current.blue
                 radius: 50
             }
 
@@ -188,7 +188,7 @@ Item {
             id: loadingImg
             visible: loading
             anchors.left: txtPassword.right
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             anchors.verticalCenter: txtPassword.verticalCenter
             // TODO replace by a real loading image
             source: "../app/img/settings.svg"
@@ -244,7 +244,7 @@ Item {
 
             StyledText {
                 id: generateKeysLinkText
-                color: Theme.blue
+                color: Style.current.blue
                 text: qsTr("Generate new keys")
                 font.pixelSize: 13
             }

--- a/ui/onboarding/Login/AccountList.qml
+++ b/ui/onboarding/Login/AccountList.qml
@@ -12,7 +12,7 @@ ListView {
     anchors.fill: parent
     model: accounts
     focus: true
-    spacing: Theme.smallPadding
+    spacing: Style.current.smallPadding
 
     delegate: AddressView {
         username: model.username

--- a/ui/onboarding/Login/AddressView.qml
+++ b/ui/onboarding/Login/AddressView.qml
@@ -19,13 +19,13 @@ Rectangle {
     anchors.right: parent.right
     anchors.left: parent.left
     border.width: 0
-    color: selected || isHovered ? Theme.grey : Theme.transparent
-    radius: Theme.radius
+    color: selected || isHovered ? Style.current.grey : Style.current.transparent
+    radius: Style.current.radius
 
     Identicon {
         id: accountImage
         anchors.left: parent.left
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
         source: identicon
     }
@@ -34,25 +34,25 @@ Rectangle {
         text: username
         elide: Text.ElideRight
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         font.pixelSize: 17
         anchors.top: accountImage.top
         anchors.left: accountImage.right
-        anchors.leftMargin: Theme.padding
+        anchors.leftMargin: Style.current.padding
     }
 
     StyledText {
         id: addressText
         width: 108
         text: address
-        font.family: Theme.fontHexRegular.name
+        font.family: Style.current.fontHexRegular.name
         elide: Text.ElideMiddle
         anchors.bottom: accountImage.bottom
         anchors.bottomMargin: 0
         anchors.left: usernameText.left
         anchors.leftMargin: 0
         font.pixelSize: 15
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
 
     MouseArea {

--- a/ui/onboarding/Login/ConfirmAddExistingKeyModal.qml
+++ b/ui/onboarding/Login/ConfirmAddExistingKeyModal.qml
@@ -17,9 +17,9 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.bottom: parent.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: "Add another existing key"
 
         onClicked : {

--- a/ui/onboarding/Login/SelectAnotherAccountModal.qml
+++ b/ui/onboarding/Login/SelectAnotherAccountModal.qml
@@ -26,9 +26,9 @@ ModalPopup {
 
     footer: StyledButton {
         anchors.bottom: parent.bottom
-        anchors.topMargin: Theme.padding
+        anchors.topMargin: Style.current.padding
         anchors.right: parent.right
-        anchors.rightMargin: Theme.padding
+        anchors.rightMargin: Style.current.padding
         label: "Add another existing key"
 
         onClicked : {

--- a/ui/onboarding/Slide.qml
+++ b/ui/onboarding/Slide.qml
@@ -53,7 +53,7 @@ Item {
         visible: !isFirst
         background: Rectangle {
             id: rctPrevious1
-            color: Theme.grey
+            color: Style.current.grey
             border.width: 0
             radius: 50
 
@@ -71,7 +71,7 @@ Item {
     StyledText {
         id: txtDesc1
         x: 772
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
         text: description
         font.weight: Font.Normal
         style: Text.Normal
@@ -97,7 +97,7 @@ Item {
         visible: !isLast
         background: Rectangle {
             id: rctNext1
-            color: Theme.grey
+            color: Style.current.grey
             border.width: 0
             radius: 50
 

--- a/ui/shared/AddButton.qml
+++ b/ui/shared/AddButton.qml
@@ -13,7 +13,7 @@ Rectangle {
     id: btnAddContainer
     width: 36
     height: 36
-    color: Theme.blue
+    color: Style.current.blue
     radius: width / 2
     
 

--- a/ui/shared/CopyToClipBoardIcon.qml
+++ b/ui/shared/CopyToClipBoardIcon.qml
@@ -22,10 +22,10 @@ Rectangle {
         anchors.fill: parent
         hoverEnabled: true
         onExited: {
-            parent.color = Theme.white
+            parent.color = Style.current.white
         }
         onEntered:{
-            parent.color = Theme.grey
+            parent.color = Style.current.grey
         }
         onClicked: onClick()
     }

--- a/ui/shared/Identicon.qml
+++ b/ui/shared/Identicon.qml
@@ -6,7 +6,7 @@ Rectangle {
     property url source:"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAg0lEQVR4nOzXwQmAMBAFURV7sQybsgybsgyr0QYUlE1g+Mw7ioQMe9lMQwhDaAyhMYTGEJqYkPnrj/t5XE/ft2UdW1yken7MRAyhMYTGEBpDaAyhKe9JbzvSX9WdLWYihtAYQuMLkcYQGkPUScxEDKExhMYQGkNoDKExhMYQmjsAAP//ZfIUZgXTZXQAAAAASUVORK5CYII="
     width: 40
     height: 40
-    color: Theme.white
+    color: Style.current.white
     radius: 50
     border.width: 1
     border.color: "#10000000"

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -10,7 +10,7 @@ Item {
     property string label: ""
     //    property string label: "My Label"
     readonly property bool hasLabel: label !== ""
-    property color bgColor: Theme.grey
+    property color bgColor: Style.current.grey
     //    property url icon: "../app/img/hash.svg"
     property url icon: ""
     property int iconHeight: 24
@@ -38,7 +38,7 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 0
         font.pixelSize: 13
-        color: Theme.black
+        color: Style.current.black
     }
 
     Rectangle {
@@ -51,7 +51,7 @@ Item {
         anchors.right: parent.right
         anchors.left: parent.left
         border.width: !!validationError ? 1 : 0
-        border.color: Theme.red
+        border.color: Style.current.red
 
         StyledTextField {
             id: inputValue
@@ -66,7 +66,7 @@ Item {
             anchors.rightMargin: parent.rightMargin
             anchors.left: parent.left
             anchors.leftMargin: 0
-            leftPadding: inputBox.hasIcon ? iconWidth + 20 : Theme.padding
+            leftPadding: inputBox.hasIcon ? iconWidth + 20 : Style.current.padding
             selectByMouse: true
             font.pixelSize: fontPixelSize
             background: Rectangle {
@@ -79,7 +79,7 @@ Item {
             sourceSize.height: iconHeight
             sourceSize.width: iconWidth
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             source: inputBox.icon
@@ -95,7 +95,7 @@ Item {
         selectByMouse: true
         readOnly: true
         font.pixelSize: 12
-        color: Theme.red
+        color: Style.current.red
 
     }
 }

--- a/ui/shared/ModalPopup.qml
+++ b/ui/shared/ModalPopup.qml
@@ -22,7 +22,7 @@ Popup {
     width: 480
     height: 510 // TODO find a way to make this dynamic
     background: Rectangle {
-        color: Theme.white
+        color: Style.current.white
         radius: 8
     }
     padding: 0
@@ -33,14 +33,14 @@ Popup {
             width: parent.width
             height: {
                 var idx = !!title ? 0 : 1
-                return children[idx] && children[idx].height + Theme.padding
+                return children[idx] && children[idx].height + Style.current.padding
             }
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.bottomMargin: Theme.padding
-            anchors.rightMargin: Theme.padding
-            anchors.leftMargin: Theme.padding
+            anchors.bottomMargin: Style.current.padding
+            anchors.rightMargin: Style.current.padding
+            anchors.leftMargin: Style.current.padding
 
             StyledText {
                 text: title
@@ -49,8 +49,8 @@ Popup {
                 font.bold: true
                 font.pixelSize: 17
                 anchors.leftMargin: 16
-                anchors.topMargin: Theme.padding
-                anchors.bottomMargin: Theme.padding
+                anchors.topMargin: Style.current.padding
+                anchors.bottomMargin: Style.current.padding
                 visible: !!title
             }
         }
@@ -60,8 +60,8 @@ Popup {
             height: 32
             width: 32
             anchors.top: parent.top
-            anchors.topMargin: Theme.padding
-            anchors.rightMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
+            anchors.rightMargin: Style.current.padding
             anchors.right: parent.right
             radius: 8
 
@@ -80,10 +80,10 @@ Popup {
                 anchors.fill: parent
                 hoverEnabled: true
                 onExited: {
-                    closeButton.color = Theme.white
+                    closeButton.color = Style.current.white
                 }
                 onEntered: {
-                    closeButton.color = Theme.grey
+                    closeButton.color = Style.current.grey
                 }
                 onClicked: {
                     popup.close()
@@ -99,13 +99,13 @@ Popup {
         Item {
             id: popupContent
             anchors.top: separator.bottom
-            anchors.topMargin: Theme.padding
+            anchors.topMargin: Style.current.padding
             anchors.bottom: separator2.top
-            anchors.bottomMargin: Theme.padding
+            anchors.bottomMargin: Style.current.padding
             anchors.left: parent.left
-            anchors.leftMargin: Theme.padding
+            anchors.leftMargin: Style.current.padding
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
         }
 
         Separator {
@@ -122,10 +122,10 @@ Popup {
           anchors.left: parent.left
           anchors.right: parent.right
           anchors.bottom: parent.bottom
-          anchors.topMargin: Theme.padding
-          anchors.bottomMargin: Theme.padding
-          anchors.rightMargin: Theme.padding
-          anchors.leftMargin: Theme.padding
+          anchors.topMargin: Style.current.padding
+          anchors.bottomMargin: Style.current.padding
+          anchors.rightMargin: Style.current.padding
+          anchors.leftMargin: Style.current.padding
         }
   }
 }

--- a/ui/shared/PopupMenu.qml
+++ b/ui/shared/PopupMenu.qml
@@ -8,14 +8,14 @@ Menu {
     property alias arrowX: bgPopupMenuTopArrow.x
     closePolicy: Popup.CloseOnPressOutsideParent
     id: popupMenu
-    topPadding: Theme.padding
-    bottomPadding: Theme.padding
+    topPadding: Style.current.padding
+    bottomPadding: Style.current.padding
     delegate: MenuItem {
         id: popupMenuItem
         implicitWidth: 200
         implicitHeight: 40
         font.pixelSize: 15
-        icon.color: popupMenuItem.action.icon.color != "#00000000" ? popupMenuItem.action.icon.color : Theme.blue
+        icon.color: popupMenuItem.action.icon.color != "#00000000" ? popupMenuItem.action.icon.color : Style.current.blue
         contentItem: Item {
             id: menuItemContent
             Item {
@@ -37,7 +37,7 @@ Menu {
                     anchors.fill: popupMenuItemIcon
                     anchors.verticalCenter: parent.verticalCenter
                     source: popupMenuItemIcon
-                    color: popupMenuItem.highlighted ? Theme.white : popupMenuItem.action.icon.color
+                    color: popupMenuItem.highlighted ? Style.current.white : popupMenuItem.action.icon.color
                 }
             }
             
@@ -47,7 +47,7 @@ Menu {
                 topPadding: 4
                 text: popupMenuItem.text
                 font: popupMenuItem.font
-                color: popupMenuItem.highlighted ? Theme.white : Theme.black
+                color: popupMenuItem.highlighted ? Style.current.white : Style.current.black
                 horizontalAlignment: Text.AlignLeft
                 verticalAlignment: Text.AlignVCenter
             }
@@ -66,7 +66,7 @@ Menu {
         color: "transparent"
         Rectangle {
             id: bgPopupMenuTopArrow
-            color: Theme.white2
+            color: Style.current.white2
             height: 14
             width: 14
             rotation: 135
@@ -92,7 +92,7 @@ Menu {
             y: 7
             implicitWidth: bgPopupMenu.width
             implicitHeight: bgPopupMenu.height
-            color: Theme.white2
+            color: Style.current.white2
             radius: 16
             layer.enabled: true
             layer.effect: DropShadow{

--- a/ui/shared/RoundedIcon.qml
+++ b/ui/shared/RoundedIcon.qml
@@ -4,7 +4,7 @@ import "../imports"
 Rectangle {
     id: root
     property int size: 36
-    property color bg: Theme.blue
+    property color bg: Style.current.blue
     property url imgPath: ""
     signal clicked
 

--- a/ui/shared/Select.qml
+++ b/ui/shared/Select.qml
@@ -7,7 +7,7 @@ import "../imports"
 Item {
     property string label: ""
     readonly property bool hasLabel: label !== ""
-    property color bgColor: Theme.grey
+    property color bgColor: Style.current.grey
     readonly property int labelMargin: 7
     property var selectOptions
     property int customHeight: 44
@@ -15,7 +15,7 @@ Item {
     property url icon: ""
     property int iconHeight: 24
     property int iconWidth: 24
-    property color iconColor: Theme.transparent
+    property color iconColor: Style.current.transparent
 
     readonly property bool hasIcon: icon.toString() !== ""
 
@@ -37,7 +37,7 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 0
         font.pixelSize: 13
-        color: Theme.black
+        color: Style.current.black
     }
 
     Rectangle {
@@ -55,7 +55,7 @@ Item {
             sourceSize.height: iconHeight
             sourceSize.width: iconWidth
             anchors.left: parent.left
-            anchors.leftMargin: Theme.smallPadding
+            anchors.leftMargin: Style.current.smallPadding
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             source: inputBox.icon
@@ -71,7 +71,7 @@ Item {
             visible: inputBox.selectedText !== ""
             text: inputBox.selectedText
             anchors.left: parent.left
-            anchors.leftMargin: inputBox.hasIcon ? iconWidth + 20 : Theme.padding
+            anchors.leftMargin: inputBox.hasIcon ? iconWidth + 20 : Style.current.padding
             anchors.verticalCenter: parent.verticalCenter
             font.pixelSize: 15
         }
@@ -81,7 +81,7 @@ Item {
             width: 11
             height: 6
             anchors.right: parent.right
-            anchors.rightMargin: Theme.padding
+            anchors.rightMargin: Style.current.padding
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             source: "../app/img/caret.svg"
@@ -89,7 +89,7 @@ Item {
         ColorOverlay {
             anchors.fill: caret
             source: caret
-            color: Theme.darkGrey
+            color: Style.current.darkGrey
         }
 
         Menu {
@@ -101,8 +101,8 @@ Item {
             background: Rectangle {
                 width: parent.width
                 height: parent.height
-                color: Theme.grey
-                radius: Theme.radius
+                color: Style.current.grey
+                radius: Style.current.radius
             }
 
             function setupMenuItems() {
@@ -132,7 +132,7 @@ Item {
                 id: menuItem
                 MenuItem {
                     property var onClicked: console.log("Default click function. Override me please")
-                    property color bgColor: Theme.white
+                    property color bgColor: Style.current.white
                     onTriggered: function () {
                         onClicked()
                     }

--- a/ui/shared/Separator.qml
+++ b/ui/shared/Separator.qml
@@ -5,6 +5,6 @@ Rectangle {
       id: separator
       width: parent.width
       height: 1
-      color: Theme.grey
-      anchors.topMargin: Theme.padding
+      color: Style.current.grey
+      anchors.topMargin: Style.current.padding
 }

--- a/ui/shared/SplitViewHandle.qml
+++ b/ui/shared/SplitViewHandle.qml
@@ -4,6 +4,6 @@ import "../imports"
 
 Rectangle {
     implicitWidth: 1.2
-    color: SplitHandle.pressed ? Theme.darkGrey
-                : (SplitHandle.hovered ? Qt.darker(Theme.grey, 1.1) : Theme.grey)
+    color: SplitHandle.pressed ? Style.current.darkGrey
+                : (SplitHandle.hovered ? Qt.darker(Style.current.grey, 1.1) : Style.current.grey)
 }

--- a/ui/shared/StatusTabButton.qml
+++ b/ui/shared/StatusTabButton.qml
@@ -11,8 +11,8 @@ TabButton {
     text: ""
     padding: 0
     background: Rectangle {
-        color: Theme.transparent
-        border.color: Theme.transparent
+        color: Style.current.transparent
+        border.color: Style.current.transparent
     }
 
     StyledText {
@@ -20,11 +20,11 @@ TabButton {
         text: btnText
         font.weight: Font.Medium
         font.pixelSize: 15
-        color: parent.checked ? Theme.black : Theme.darkGrey
+        color: parent.checked ? Style.current.black : Style.current.darkGrey
     }
 
     Rectangle {
-        color: Theme.blue
+        color: Style.current.blue
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
         anchors.right: parent.right

--- a/ui/shared/StyledButton.qml
+++ b/ui/shared/StyledButton.qml
@@ -5,20 +5,20 @@ import "../imports"
 
 Button {
     property string label: "My button"
-    property color btnColor: Theme.lightBlue
+    property color btnColor: Style.current.lightBlue
     property color btnBorderColor: "transparent"
     property int btnBorderWidth: 0
-    property color textColor: Theme.blue
+    property color textColor: Style.current.blue
     property bool disabled: false
 
     id: btnStyled
-    width: txtBtnLabel.width + 2 * Theme.padding
+    width: txtBtnLabel.width + 2 * Style.current.padding
     height: 44
     enabled: !disabled
 
     background: Rectangle {
-        color: disabled ? Theme.grey : btnStyled.btnColor
-        radius: Theme.radius
+        color: disabled ? Style.current.grey : btnStyled.btnColor
+        radius: Style.current.radius
         anchors.fill: parent
         border.color: btnBorderColor
         border.width: btnBorderWidth
@@ -26,7 +26,7 @@ Button {
 
     StyledText {
         id: txtBtnLabel
-        color: btnStyled.disabled ? Theme.darkGrey : btnStyled.textColor
+        color: btnStyled.disabled ? Style.current.darkGrey : btnStyled.textColor
         font.pixelSize: 15
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/shared/StyledTArea.qml
+++ b/ui/shared/StyledTArea.qml
@@ -3,5 +3,5 @@ import QtQuick.Controls 2.13
 import "../imports"
 
 TextArea {
-    font.family: Theme.fontRegular.name
+    font.family: Style.current.fontRegular.name
 }

--- a/ui/shared/StyledText.qml
+++ b/ui/shared/StyledText.qml
@@ -2,5 +2,5 @@ import QtQuick 2.13
 import "../imports"
 
 Text {
-    font.family: Theme.fontRegular.name
+    font.family: Style.current.fontRegular.name
 }

--- a/ui/shared/StyledTextArea.qml
+++ b/ui/shared/StyledTextArea.qml
@@ -12,7 +12,7 @@ Item {
     //    property string label: "My Label"
     property string label: ""
     readonly property bool hasLabel: label !== ""
-    property color bgColor: Theme.grey
+    property color bgColor: Style.current.grey
     readonly property var forceActiveFocus: function () {
         textArea.forceActiveFocus(Qt.MouseFocusReason)
     }
@@ -33,7 +33,7 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 0
         font.pixelSize: 13
-        color: Theme.black
+        color: Style.current.black
     }
 
     Rectangle {
@@ -46,7 +46,7 @@ Item {
         anchors.right: parent.right
         anchors.left: parent.left
         border.width: !!validationError ? 1 : 0
-        border.color: Theme.red
+        border.color: Style.current.red
 
         TextArea {
             id: textArea
@@ -54,12 +54,12 @@ Item {
             font.pixelSize: 15
             wrapMode: Text.WordWrap
             placeholderText: inputBox.placeholderText
-            anchors.rightMargin: Theme.padding
-            anchors.leftMargin: inputBox.hasIcon ? 36 : Theme.padding
-            anchors.bottomMargin: Theme.smallPadding
-            anchors.topMargin: Theme.smallPadding
+            anchors.rightMargin: Style.current.padding
+            anchors.leftMargin: inputBox.hasIcon ? 36 : Style.current.padding
+            anchors.bottomMargin: Style.current.smallPadding
+            anchors.topMargin: Style.current.smallPadding
             anchors.fill: parent
-            font.family: Theme.fontRegular.name
+            font.family: Style.current.fontRegular.name
         }
 
         MouseArea {
@@ -80,7 +80,7 @@ Item {
         selectByMouse: true
         readOnly: true
         font.pixelSize: 12
-        color: Theme.red
+        color: Style.current.red
 
     }
 }

--- a/ui/shared/StyledTextEdit.qml
+++ b/ui/shared/StyledTextEdit.qml
@@ -2,5 +2,5 @@ import QtQuick 2.13
 import "../imports"
 
 TextEdit {
-    font.family: Theme.fontRegular.name
+    font.family: Style.current.fontRegular.name
 }

--- a/ui/shared/StyledTextField.qml
+++ b/ui/shared/StyledTextField.qml
@@ -3,5 +3,5 @@ import QtQuick.Controls 2.13
 import "../imports"
 
 TextField {
-    font.family: Theme.fontRegular.name
+    font.family: Style.current.fontRegular.name
 }

--- a/ui/shared/TextWithLabel.qml
+++ b/ui/shared/TextWithLabel.qml
@@ -6,7 +6,7 @@ import "../imports"
 Item {
     property string text: "My Text"
     property string label: "My Label"
-    property string fontFamily: Theme.fontRegular.name
+    property string fontFamily: Style.current.fontRegular.name
     readonly property int labelMargin: 7
 
     id: inputBox
@@ -23,7 +23,7 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 0
         font.pixelSize: 13
-        color: Theme.darkGrey
+        color: Style.current.darkGrey
     }
 
     StyledTextEdit {
@@ -38,7 +38,7 @@ Item {
         anchors.top: inputLabel.bottom
         anchors.topMargin: inputBox.labelMargin
         font.pixelSize: 15
-        color: Theme.black
+        color: Style.current.black
     }
 }
 


### PR DESCRIPTION
Makes it possible to switch between theme, right now dark and light. 
This PR doesn't implement the dark theme design, just the switching and saving.
Important note: `Theme` no longer is what it was. Now, you must access style values as `Style.current.value`, example: `Style.current.blue`

It's beautiful:
![image](https://user-images.githubusercontent.com/11926403/86375901-476fb780-bc54-11ea-9151-04771ea1fec8.png)
