### PR TITLE
refactor: store data folder in OS appropriate location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,13 +304,18 @@ clean: | clean-common
 
 run: rcc $(RUN_TARGET)
 
+NIM_STATUS_CLIENT_DEV ?= t
+
 run-linux-or-macos:
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client"
-	LD_LIBRARY_PATH="$(QT5_LIBDIR)" ./bin/nim_status_client
+	NIM_STATUS_CLIENT_DEV="$(NIM_STATUS_CLIENT_DEV)" \
+	LD_LIBRARY_PATH="$(QT5_LIBDIR)" \
+	./bin/nim_status_client
 
 run-windows:
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client.exe"
+	NIM_STATUS_CLIENT_DEV="$(NIM_STATUS_CLIENT_DEV)" \
 	PATH="$(shell pwd)"/"$(shell dirname "$(DOTHERSIDE)")":"$(PATH)" \
-		./bin/nim_status_client
+	./bin/nim_status_client.exe
 
 endif # "variables.mk" was not included

--- a/src/status/libstatus/accounts.nim
+++ b/src/status/libstatus/accounts.nim
@@ -38,7 +38,6 @@ proc ensureDir(dirname: string) =
 proc initNode*() =
   ensureDir(DATADIR)
   ensureDir(KEYSTOREDIR)
-  ensureDir(NOBACKUPDIR)
 
   discard $libstatus.initKeystore(KEYSTOREDIR)
 
@@ -91,10 +90,10 @@ proc storeDerivedAccounts*(account: GeneratedAccount, password: string): MultiAc
     "password": hashedPassword
   }
   let response = $libstatus.multiAccountStoreDerivedAccounts($multiAccount);
-  
-  try: 
+
+  try:
     result = Json.decode($response, MultiAccounts)
-  except: 
+  except:
     let err = Json.decode($response, StatusGoError)
     raise newException(StatusGoException, "Error storing multiaccount derived accounts: " & err.error)
 

--- a/src/status/libstatus/accounts/constants.nim
+++ b/src/status/libstatus/accounts/constants.nim
@@ -1,4 +1,5 @@
 import json
+import os
 
 const GENERATED* = "generated"
 const SEED* = "seed"
@@ -178,6 +179,35 @@ var NODE_CONFIG* = %* {
   }
 }
 
-const DATADIR* = "./data/"
-const KEYSTOREDIR* = "./data/keystore/"
-const NOBACKUPDIR* = "./noBackup/"
+let sep = if defined(windows): "\\" else: "/"
+
+let homeDir = getHomeDir()
+
+let parentDir =
+  if getEnv("NIM_STATUS_CLIENT_DEV").string != "":
+    "."
+  elif homeDir == "":
+    "."
+  elif defined(macosx):
+    joinPath(homeDir, "Library", "Application Support")
+  elif defined(windows):
+    let targetDir = getEnv("LOCALAPPDATA").string
+    if targetDir == "":
+      joinPath(homeDir, "AppData", "Local")
+    else:
+      targetDir
+  else:
+    let targetDir = getEnv("XDG_CONFIG_HOME").string
+    if targetDir == "":
+      joinPath(homeDir, ".config")
+    else:
+      targetDir
+
+let clientDir =
+  if parentDir != ".":
+    joinPath(parentDir, "Status")
+  else:
+    parentDir
+
+let DATADIR* = joinPath(clientDir, "data") & sep
+let KEYSTOREDIR* = joinPath(clientDir, "data", "keystore") & sep


### PR DESCRIPTION
If the environment variable `NIM_STATUS_CLIENT_DEV` is not empty then the `./data` dir is created/used relative to the current working directory, as was always the case prior to the changes introduced in this commit.

`NIM_STATUS_CLIENT_DEV` is set to `t` when doing `make run`. To get the production behavior in development do:

```
$ NIM_STATUS_CLIENT_DEV="" make run
```
or on Windows in a Bash shell:
```
$ NIM_STATUS_CLIENT_DEV="" mingw32-make run
```

Closes #391

---

Per @zah's [comment](https://github.com/status-im/nim-status-client/issues/391#issuecomment-648006108) we can/should refine this at some point.