### PR TITLE
build: enhance build system so that it can run directly on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 	pkg \
 	pkg-linux \
 	pkg-macos \
+	pkg-windows \
 	run \
+	run-linux-or-macos \
+	run-windows \
 	status-go \
 	update
 
@@ -54,18 +57,24 @@ else
  detected_OS := $(strip $(shell uname))
 endif
 
-ifeq ($(detected_OS), Darwin)
+ifeq ($(detected_OS),Darwin)
  BOTTLES_TARGET := bottles-macos
- PKG_TARGET := pkg-macos
- MACOSX_DEPLOYMENT_TARGET := 10.13
- export MACOSX_DEPLOYMENT_TARGET
- CGO_CFLAGS := -mmacosx-version-min=10.13
- export CGO_CFLAGS
  CFLAGS := -mmacosx-version-min=10.13
  export CFLAGS
+ CGO_CFLAGS := -mmacosx-version-min=10.13
+ export CGO_CFLAGS
+ MACOSX_DEPLOYMENT_TARGET := 10.13
+ export MACOSX_DEPLOYMENT_TARGET
+ PKG_TARGET := pkg-macos
+ RUN_TARGET := run-linux-or-macos
+else ifeq ($(detected_OS),Windows)
+ BOTTLES_TARGET := bottles-dummy
+ PKG_TARGET := pkg-windows
+ RUN_TARGET := run-windows
 else
  BOTTLES_TARGET := bottles-dummy
  PKG_TARGET := pkg-linux
+ RUN_TARGET := run-linux-or-macos
 endif
 
 bottles: $(BOTTLES_TARGET)
@@ -75,6 +84,7 @@ bottles-dummy: ;
 BOTTLE_OPENSSL := bottles/openssl/INSTALL_RECEIPT.json
 
 $(BOTTLE_OPENSSL):
+	echo -e "\e[92mFetching:\e[39m bottles for macOS"
 	rm -rf bottles/Downloads/openssl* bottles/openssl*
 	mkdir -p bottles/Downloads
 	cd bottles/Downloads && \
@@ -95,36 +105,45 @@ $(BOTTLE_PCRE):
 bottles-macos: | $(BOTTLE_OPENSSL) $(BOTTLE_PCRE)
 	rm -rf bottles/Downloads
 
-ifeq ($(detected_OS), Darwin)
- NIM_PARAMS += -L:"-framework Foundation -framework Security -framework IOKit -framework CoreServices"
- # Fix for failures due to 'can't allocate code signature data for'
- NIM_PARAMS += --passL:"-headerpad_max_install_names"
-endif
+deps: | deps-common bottles
 
-DOTHERSIDE := vendor/DOtherSide/build/lib/libDOtherSideStatic.a
+update: | update-common
 
 # Qt5 dirs (we can't indent with tabs here)
-QT5_PCFILEDIR := $(shell pkg-config --variable=pcfiledir Qt5Core 2>/dev/null)
-QT5_LIBDIR := $(shell pkg-config --variable=libdir Qt5Core 2>/dev/null)
-ifeq ($(QT5_PCFILEDIR),)
- ifeq ($(QTDIR),)
-  $(error Cannot find your Qt5 installation. Please run "$(MAKE) QTDIR=/path/to/your/Qt5/installation/prefix ...")
- else
-  ifeq ($(detected_OS), Darwin)
-   QT5_PCFILEDIR := $(QTDIR)/lib/pkgconfig
-   QT5_LIBDIR := $(QTDIR)/lib
-   # some manually installed Qt5 instances have wrong paths in their *.pc files, so we pass the right one to the linker here
-   NIM_PARAMS += --passL:"-F$(QT5_LIBDIR)"
+ifneq ($(detected_OS),Windows)
+ QT5_PCFILEDIR := $(shell pkg-config --variable=pcfiledir Qt5Core 2>/dev/null)
+ QT5_LIBDIR := $(shell pkg-config --variable=libdir Qt5Core 2>/dev/null)
+ ifeq ($(QT5_PCFILEDIR),)
+  ifeq ($(QTDIR),)
+   $(error Cannot find your Qt5 installation. Please run "$(MAKE) QTDIR=/path/to/your/Qt5/installation/prefix ...")
   else
    QT5_PCFILEDIR := $(QTDIR)/lib/pkgconfig
    QT5_LIBDIR := $(QTDIR)/lib
-   NIM_PARAMS += --passL:"-L$(QT5_LIBDIR)"
+   # some manually installed Qt5 instances have wrong paths in their *.pc files, so we pass the right one to the linker here
+   ifeq ($(detected_OS),Darwin)
+    NIM_PARAMS += -L:"-framework Foundation -framework Security -framework IOKit -framework CoreServices"
+    # Fix for failures due to 'can't allocate code signature data for'
+    NIM_PARAMS += --passL:"-headerpad_max_install_names"
+    NIM_PARAMS += --passL:"-F$(QT5_LIBDIR)"
+    export QT5_LIBDIR
+   else
+    NIM_PARAMS += --passL:"-L$(QT5_LIBDIR)"
+   endif
   endif
  endif
+ DOTHERSIDE := vendor/DOtherSide/build/lib/libDOtherSideStatic.a
+ DOTHERSIDE_CMAKE_PARAMS := -DENABLE_DYNAMIC_LIBS=OFF -DENABLE_STATIC_LIBS=ON
+ DOTHERSIDE_BUILD_CMD := $(MAKE) VERBOSE=$(V) $(HANDLE_OUTPUT)
+ # order matters here, due to "-Wl,-as-needed"
+ NIM_PARAMS += --passL:"$(DOTHERSIDE)" --passL:"$(shell PKG_CONFIG_PATH="$(QT5_PCFILEDIR)" pkg-config --libs Qt5Core Qt5Qml Qt5Gui Qt5Quick Qt5QuickControls2 Qt5Widgets Qt5Svg)"
+else
+ DOTHERSIDE := vendor/DOtherSide/build/lib/Release/DOtherSide.dll
+ DOTHERSIDE_CMAKE_PARAMS := -T"v141" -A x64 -DENABLE_DYNAMIC_LIBS=ON -DENABLE_STATIC_LIBS=OFF
+ DOTHERSIDE_BUILD_CMD := cmake --build . --config Release $(HANDLE_OUTPUT)
+ NIM_PARAMS += -L:$(DOTHERSIDE)
+ NIM_EXTRA_PARAMS := --passL:"-lsetupapi -lhid"
+ QRCODEGEN_MAKE_PARAMS := CC=gcc
 endif
-export QT5_LIBDIR
-# order matters here, due to "-Wl,-as-needed"
-NIM_PARAMS += --passL:"$(DOTHERSIDE) $(shell PKG_CONFIG_PATH="$(QT5_PCFILEDIR)" pkg-config --libs Qt5Core Qt5Qml Qt5Gui Qt5Quick Qt5QuickControls2 Qt5Widgets Qt5Svg)"
 
 # TODO: control debug/release builds with a Make var
 # We need `-d:debug` to get Nim's default stack traces.
@@ -133,24 +152,18 @@ NIM_PARAMS += --outdir:./bin -d:debug
 CFLAGS += -g
 CXXFLAGS += -g
 
-deps: | deps-common bottles
-
-update: | update-common
-
 $(DOTHERSIDE): | deps
 	echo -e $(BUILD_MSG) "DOtherSide"
 	+ cd vendor/DOtherSide && \
 		mkdir -p build && \
 		cd build && \
 		rm -f CMakeCache.txt && \
-		cmake \
+		cmake $(DOTHERSIDE_CMAKE_PARAMS)\
 			-DCMAKE_BUILD_TYPE=Release \
 			-DENABLE_DOCS=OFF \
 			-DENABLE_TESTS=OFF \
-			-DENABLE_DYNAMIC_LIBS=OFF \
-			-DENABLE_STATIC_LIBS=ON \
 			.. $(HANDLE_OUTPUT) && \
-		$(MAKE) VERBOSE=$(V) $(HANDLE_OUTPUT)
+		$(DOTHERSIDE_BUILD_CMD)
 
 STATUSGO := vendor/status-go/build/bin/libstatus.a
 
@@ -165,9 +178,10 @@ QRCODEGEN := vendor/QR-Code-generator/c/libqrcodegen.a
 $(QRCODEGEN): | deps
 	echo -e $(BUILD_MSG) "QR-Code-generator"
 	+ cd vendor/QR-Code-generator/c && \
-	  $(MAKE)
+	  $(MAKE) $(QRCODEGEN_MAKE_PARAMS)
 
 rcc:
+	echo -e $(BUILD_MSG) "resources.rcc"
 	rm -f ./resources.rcc
 	rm -f ./ui/resources.qrc
 	./ui/generate-rcc.sh
@@ -175,12 +189,13 @@ rcc:
 
 nim_status_client: | $(DOTHERSIDE) $(STATUSGO) $(QRCODEGEN) rcc deps
 	echo -e $(BUILD_MSG) "$@" && \
-		$(ENV_SCRIPT) nim c $(NIM_PARAMS) --passL:"$(STATUSGO)" --passL:"$(QRCODEGEN)" --passL:"-lm" src/nim_status_client.nim
+		$(ENV_SCRIPT) nim c $(NIM_PARAMS) --passL:"$(STATUSGO)" $(NIM_EXTRA_PARAMS) --passL:"$(QRCODEGEN)" --passL:"-lm" src/nim_status_client.nim
 
 _APPIMAGE_TOOL := appimagetool-x86_64.AppImage
 APPIMAGE_TOOL := tmp/linux/tools/$(_APPIMAGE_TOOL)
 
 $(APPIMAGE_TOOL):
+	echo -e "\e[92mFetching:\e[39m appimagetool"
 	rm -rf tmp/linux
 	mkdir -p tmp/linux/tools
 	wget https://github.com/AppImage/AppImageKit/releases/download/continuous/$(_APPIMAGE_TOOL)
@@ -214,6 +229,7 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 DMG_TOOL := node_modules/.bin/create-dmg
 
 $(DMG_TOOL):
+	echo -e "\e[92mInstalling:\e[39m create-dmg"
 	npm i
 
 MACOS_OUTER_BUNDLE := tmp/macos/dist/Status.app
@@ -233,6 +249,7 @@ $(STATUS_CLIENT_DMG): nim_status_client $(DMG_TOOL)
 	cp status.svg $(MACOS_OUTER_BUNDLE)/Contents/
 	cp -R resources.rcc $(MACOS_OUTER_BUNDLE)/Contents/
 
+	echo -e $(BUILD_MSG) "app"
 	macdeployqt \
 		$(MACOS_OUTER_BUNDLE) \
 		-executable=$(MACOS_OUTER_BUNDLE)/Contents/MacOS/nim_status_client \
@@ -249,6 +266,7 @@ ifdef MACOS_CODESIGN_IDENT
 	scripts/sign-macos-pkg.sh $(MACOS_INNER_BUNDLE) $(MACOS_CODESIGN_IDENT) \
 		--entitlements QtWebEngineProcess.plist
 endif
+	echo -e $(BUILD_MSG) "dmg"
 	mkdir -p pkg
 	# See: https://github.com/sindresorhus/create-dmg#dmg-icon
 	# GraphicsMagick must be installed for create-dmg to make the custom
@@ -267,17 +285,32 @@ ifdef MACOS_CODESIGN_IDENT
 	scripts/sign-macos-pkg.sh $(STATUS_CLIENT_DMG) $(MACOS_CODESIGN_IDENT)
 endif
 
+STATUS_CLIENT_EXE ?= pkg/Status.exe
+
+# not implemented yet
+# $(STATUS_CLIENT_EXE): nim_status_client
+
 pkg: $(PKG_TARGET)
 
 pkg-linux: $(STATUS_CLIENT_APPIMAGE)
 
 pkg-macos: $(STATUS_CLIENT_DMG)
 
+pkg-windows: $(STATUS_CLIENT_EXE)
+
 clean: | clean-common
 	rm -rf bin/* node_modules pkg/* tmp/* $(STATUSGO)
 	+ $(MAKE) -C vendor/DOtherSide/build --no-print-directory clean
 
-run: | rcc
+run: rcc $(RUN_TARGET)
+
+run-linux-or-macos:
+	echo -e "\e[92mRunning:\e[39m bin/nim_status_client"
 	LD_LIBRARY_PATH="$(QT5_LIBDIR)" ./bin/nim_status_client
+
+run-windows:
+	echo -e "\e[92mRunning:\e[39m bin/nim_status_client.exe"
+	PATH="$(shell pwd)"/"$(shell dirname "$(DOTHERSIDE)")":"$(PATH)" \
+		./bin/nim_status_client
 
 endif # "variables.mk" was not included

--- a/config.nims
+++ b/config.nims
@@ -6,10 +6,10 @@ else:
 --threads:on
 --opt:speed # -O3
 --debugger:native # passes "-g" to the C compiler
---dynliboverrideall # don't use dlopen()
 --define:ssl # needed by the stdlib to enable SSL procedures
 
 if defined(macosx):
+  --dynlibOverrideAll # don't use dlopen()
   --tlsEmulation:off
   switch("passL", "-lstdc++")
   # DYLD_LIBRARY_PATH doesn't seem to work with Qt5
@@ -22,7 +22,11 @@ if defined(macosx):
   switch("passL", "-Wl,-no_compact_unwind")
   # set the minimum supported macOS version to 10.13
   switch("passC", "-mmacosx-version-min=10.13")
+elif defined(windows):
+  --tlsEmulation:off
+  switch("passL", "-Wl,-as-needed")
 else:
+  --dynlibOverrideAll # don't use dlopen()
   # dynamically link these libs, since we're opting out of dlopen()
   switch("passL", "-lcrypto")
   switch("passL", "-lssl")


### PR DESCRIPTION
Replaces #82, which in any case is out-of-date re: the current state of this repo's Makefile.

Introduces the ability to build `nim_status_client.exe` directly on Windows, i.e. without needing to use Windows Subsystem for Linux or otherwise cross-compile on Linux.

Note: this commit does not introduce packaging or code signing for the Windows build as those pieces are still a work in progress.

The `make` targets should be run in a Bash shell, e.g. in *Git Bash* as included in the installation of [Git for Windows][git-win].

[Microsoft Visual C++ Build Tools][ms-build] must be installed.

Qt's `MSVC 2017 64-bit` and `MinGW 7.3.0 64-bit` toolchains must both be installed, e.g. with the Qt Online Installer tool.

CMake needs to be installed; it is available via the Qt Online Installer tool under *Developer and Designer Tools* (`CMake 3.17.1 64-bit`).

A couple of additional tools need to be installed (e.g. with [scoop][scoop]) and availble in `PATH`:
* findutils
* go

For `.dll` resolution to function as needed, in a Bash shell `PATH` should be modified like this (might be different depending on how/where things were installed):

```bash
export QTBASE="/c/Qt"
export QTDIR="${QTBASE}/5.14.2/msvc2017_64"

export PATH="${HOME}/scoop/shims:${PATH}"
export PATH="${QTDIR}/bin:${PATH}"
export PATH="${QTBASE}/Tools/mingw730_64/bin:${PATH}"
export PATH="${QTBASE}/Tools/CMake_64/bin:${PATH}"
```

With those modifications in place, to build `nim_status_client.exe` do:
```
mingw32-make.exe V=1
```

To run the executable do:
```
mingw32-make.exe run
```

[git-win]: https://gitforwindows.org/
[ms-build]: https://visualstudio.microsoft.com/visual-cpp-build-tools/
[scoop]: https://scoop.sh/

---

There is a known problem (#522) that causes `nim_status_client.exe` to frequently crash shortly after it's launched. However, the problem doesn't affect building the `.exe`.