### PR TITLE
Feat/support paid sticker packs

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -40,15 +40,18 @@ proc init*(self: ChatController) =
   let currAcct = status_wallet.getWalletAccounts()[0] # TODO: make generic
   let currAddr = parseAddress(currAcct.address)
 
-  let installedStickerPacks = self.status.chat.getInstalledStickerPacks(currAddr)
+  let installedStickerPacks = self.status.chat.getInstalledStickerPacks()
+
+  let purchasedStickerPacks = self.status.chat.getPurchasedStickerPacks(currAddr)
 
   # TODO: getting available stickers should be done in a separate thread as there
   # a long wait for contract response, decoded, downloading from IPFS, EDN decoding,
   # etc
-  let availableStickerPacks = self.status.chat.getAvailableStickerPacks(currAddr)
+  let availableStickerPacks = self.status.chat.getAvailableStickerPacks()
   for packId, stickerPack in availableStickerPacks.pairs:
     let isInstalled = installedStickerPacks.hasKey(packId)
-    self.view.addStickerPackToList(stickerPack, isInstalled)
+    let isBought = purchasedStickerPacks.contains(packId)
+    self.view.addStickerPackToList(stickerPack, isInstalled, isBought)
 
   let recentStickers = self.status.chat.getRecentStickers()
   for sticker in recentStickers:

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -48,8 +48,8 @@ QtObject:
     result.recentStickers = newStickerList()
     result.setup()
 
-  proc addStickerPackToList*(self: ChatsView, stickerPack: StickerPack, isInstalled: bool) =
-    self.stickerPacks.addStickerPackToList(stickerPack, newStickerList(stickerPack.stickers), isInstalled)
+  proc addStickerPackToList*(self: ChatsView, stickerPack: StickerPack, isInstalled, isBought: bool) =
+    self.stickerPacks.addStickerPackToList(stickerPack, newStickerList(stickerPack.stickers), isInstalled, isBought)
   
   proc getStickerPackList(self: ChatsView): QVariant {.slot.} =
     newQVariant(self.stickerPacks)

--- a/src/app/chat/views/sticker_pack_list.nim
+++ b/src/app/chat/views/sticker_pack_list.nim
@@ -12,9 +12,10 @@ type
     Stickers = UserRole + 6
     Thumbnail = UserRole + 7
     Installed = UserRole + 8
+    Bought = UserRole + 9
 
 type
-  StickerPackView* = tuple[pack: StickerPack, stickers: StickerList, installed: bool]
+  StickerPackView* = tuple[pack: StickerPack, stickers: StickerList, installed, bought: bool]
 
 QtObject:
   type
@@ -50,6 +51,7 @@ QtObject:
       of StickerPackRoles.Stickers: result = newQVariant(packInfo.stickers)
       of StickerPackRoles.Thumbnail: result = newQVariant(decodeContentHash(stickerPack.thumbnail))
       of StickerPackRoles.Installed: result = newQVariant(packInfo.installed)
+      of StickerPackRoles.Bought: result = newQVariant(packInfo.bought)
 
   method roleNames(self: StickerPackList): Table[int, string] =
     {
@@ -60,7 +62,8 @@ QtObject:
       StickerPackRoles.Preview.int: "preview",
       StickerPackRoles.Stickers.int: "stickers",
       StickerPackRoles.Thumbnail.int: "thumbnail",
-      StickerPackRoles.Installed.int: "installed"
+      StickerPackRoles.Installed.int: "installed",
+      StickerPackRoles.Bought.int: "bought"
     }.toTable
 
 
@@ -82,9 +85,9 @@ QtObject:
       raise newException(ValueError, "Sticker pack list does not have a pack with id " & $packId)
     result = self.packs.filterIt(it.pack.id == packId)[0].pack
 
-  proc addStickerPackToList*(self: StickerPackList, pack: StickerPack, stickers: StickerList, installed: bool) =
+  proc addStickerPackToList*(self: StickerPackList, pack: StickerPack, stickers: StickerList, installed, bought: bool) =
     self.beginInsertRows(newQModelIndex(), 0, 0)
-    self.packs.insert((pack: pack, stickers: stickers, installed: installed), 0)
+    self.packs.insert((pack: pack, stickers: stickers, installed: installed, bought: bought), 0)
     self.endInsertRows()
 
   proc removeStickerPackFromList*(self: StickerPackList, packId: int) =

--- a/src/status/libstatus/types.nim
+++ b/src/status/libstatus/types.nim
@@ -1,4 +1,5 @@
-import eventemitter, json_serialization, stint, json
+import eventemitter, json
+import eth/common/eth_types, stew/byteutils, json_serialization, stint
 import accounts/constants
 
 type SignalCallback* = proc(eventMessage: cstring): void {.cdecl.}
@@ -117,6 +118,9 @@ type StickerPack* = object
 
 proc `%`*(stuint256: Stuint[256]): JsonNode =
   newJString($stuint256)
+
+proc `$`*(a: EthAddress): string =
+  "0x" & a.toHex()
 
 proc readValue*(reader: var JsonReader, value: var Stuint[256])
                {.raises: [IOError, SerializationError, Defect].} =

--- a/ui/app/AppLayouts/Chat/components/StickerMarket.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerMarket.qml
@@ -68,6 +68,7 @@ Item {
                     style: StickerButton.StyleType.LargeNoIcon
                     packPrice: price
                     isInstalled: installed
+                    isBought: bought
                     onInstallClicked: root.installClicked(stickers, packId, index)
                     onUninstallClicked: root.uninstallClicked(packId)
                     onCancelClicked: root.cancelClicked(packId)
@@ -100,6 +101,7 @@ Item {
                     packPrice: price
                     width: 75 // only needed for Qt Creator
                     isInstalled: installed
+                    isBought: bought
                     onInstallClicked: root.installClicked(stickers, packId, index)
                     onUninstallClicked: root.uninstallClicked(packId)
                     onCancelClicked: root.cancelClicked(packId)

--- a/ui/app/AppLayouts/Chat/components/StickersPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/StickersPopup.qml
@@ -185,7 +185,7 @@ Popup {
 
                 Repeater {
                     id: stickerPackListView
-                    property int selectedPackId
+                    property int selectedPackId: -1
                     model: stickerPackList
 
                     delegate: StickerPackIconWithIndicator {


### PR DESCRIPTION
Fixes #484 

Sticker packs which have been previously purchased can be installed in the application. This data is held in the Sticker Market contracts. If a sticker pack has been previously purchased, the sticker pack button in the Sticker Market popup will show "Install", instead of the price or "Free".

### Note
This PR is based off `feat/install-sticker-pack` from PR https://github.com/status-im/nim-status-client/pull/545. Please hold off merging this PR until that PR is merged.