### PR TITLE
feat: Enable switching to testnet

### DIFF
--- a/src/app/chat/views/sticker_pack_list.nim
+++ b/src/app/chat/views/sticker_pack_list.nim
@@ -44,7 +44,7 @@ QtObject:
     let stickerPackRole = role.StickerPackRoles
     case stickerPackRole:
       of StickerPackRoles.Author: result = newQVariant(stickerPack.author)
-      of StickerPackRoles.Id: result = newQVariant($stickerPack.id)
+      of StickerPackRoles.Id: result = newQVariant(stickerPack.id)
       of StickerPackRoles.Name: result = newQVariant(stickerPack.name)
       of StickerPackRoles.Price: result = newQVariant(stickerPack.price.wei2Eth)
       of StickerPackRoles.Preview: result = newQVariant(decodeContentHash(stickerPack.preview))

--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -2,6 +2,7 @@ import NimQml, json, eventemitter, strutils
 import json_serialization
 import ../../status/libstatus/mailservers as status_mailservers
 import ../../signals/types
+import ../../status/libstatus/accounts/constants
 import ../../status/libstatus/types as status_types
 import ../../status/libstatus/settings as status_settings
 import ../../status/profile/[profile, mailserver]
@@ -34,9 +35,10 @@ proc init*(self: ProfileController, account: Account) =
   # Ideally, this module should call getSettings once, and fill the 
   # profile with all the information comming from the settings.
   let response = status_settings.getSettings()
-  let pubKey = status_settings.getSetting[string]("public-key", "0x0")
-  let mnemonic = status_settings.getSetting[string]("mnemonic", "")
-  let appearance = Json.decode($response["appearance"], int)
+  let pubKey = status_settings.getSetting[string](Setting.PublicKey, "0x0")
+  let mnemonic = status_settings.getSetting[string](Setting.Mnemonic, "")
+  let network = status_settings.getSetting[string](Setting.Networks_CurrentNetwork, constants.DEFAULT_NETWORK_NAME)
+  let appearance = status_settings.getSetting[int](Setting.Appearance)
   profile.appearance = appearance
   profile.id = pubKey
 
@@ -44,6 +46,7 @@ proc init*(self: ProfileController, account: Account) =
   self.view.setDeviceSetup(devices.isDeviceSetup())
   self.view.setNewProfile(profile)
   self.view.setMnemonic(mnemonic)
+  self.view.setNetwork(network)
 
   var mailservers = status_mailservers.getMailservers()
   for mailserver_config in mailservers:

--- a/src/signals/messages.nim
+++ b/src/signals/messages.nim
@@ -2,6 +2,7 @@ import json, random, re, strutils, sequtils, sugar
 import json_serialization
 import ../status/libstatus/accounts as status_accounts
 import ../status/libstatus/settings as status_settings
+import ../status/libstatus/types as status_types
 import ../status/chat/[chat, message]
 import ../status/profile/[profile, devices]
 import types
@@ -15,7 +16,7 @@ proc fromEvent*(event: JsonNode): Signal =
   signal.messages = @[]
   signal.contacts = @[]
 
-  let pk = status_settings.getSetting[string]("public-key", "0x0")
+  let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
 
   if event["event"]{"contacts"} != nil:
     for jsonContact in event["event"]["contacts"]:

--- a/src/status/devices.nim
+++ b/src/status/devices.nim
@@ -6,10 +6,10 @@ import profile/devices
 import json
 
 proc setDeviceName*(name: string) =
-  discard setInstallationMetadata(getSetting[string]("installation-id", "", true), name, hostOs)
+  discard setInstallationMetadata(getSetting[string](Setting.InstallationId, "", true), name, hostOs)
 
 proc isDeviceSetup*():bool =
-  let installationId = getSetting[string]("installation-id", "", true)
+  let installationId = getSetting[string](Setting.InstallationId, "", true)
   let responseResult = getOurInstallations()
   if responseResult.kind == JNull:
     return false
@@ -26,7 +26,7 @@ proc advertise*() =
 
 proc getAllDevices*():seq[Installation] =
   let responseResult = getOurInstallations()
-  let installationId = getSetting[string]("installation-id", "", true)
+  let installationId = getSetting[string](Setting.InstallationId, "", true)
   result = @[]
   if responseResult.kind != JNull:
     for inst in responseResult:

--- a/src/status/libstatus/accounts/constants.nim
+++ b/src/status/libstatus/accounts/constants.nim
@@ -179,6 +179,8 @@ var NODE_CONFIG* = %* {
   }
 }
 
+const DEFAULT_NETWORK_NAME* = "mainnet_rpc"
+
 let sep = if defined(windows): "\\" else: "/"
 
 let homeDir = getHomeDir()

--- a/src/status/libstatus/contracts.nim
+++ b/src/status/libstatus/contracts.nim
@@ -1,11 +1,7 @@
 import sequtils, strformat, sugar, macros, tables
 import eth/common/eth_types, stew/byteutils, nimcrypto
 from eth/common/utils import parseAddress
-
-type
-  Network* {.pure.} = enum
-    Mainnet,
-    Testnet
+import ./types, ./settings
 
 type Method* = object
   name*: string
@@ -103,9 +99,13 @@ let CONTRACTS: seq[Contract] = @[
   Contract(name: "crypto-kitties", network: Network.Mainnet, address: parseAddress("0x06012c8cf97bead5deae237070f9587f8e7a266d")),
 ]
 
-proc getContract*(network: Network, name: string): Contract =
+proc getContract(network: Network, name: string): Contract =
   let found = CONTRACTS.filter(contract => contract.name == name and contract.network == network)
   result = if found.len > 0: found[0] else: nil
+
+proc getContract*(name: string): Contract =
+  let network = settings.getCurrentNetwork()
+  getContract(network, name)
 
 func encode*[bits: static[int]](x: Stuint[bits]): EncodeResult =
   ## Encodes a `Stuint` to a textual representation for use in the JsonRPC

--- a/src/status/libstatus/types.nim
+++ b/src/status/libstatus/types.nim
@@ -133,3 +133,19 @@ proc readValue*(reader: var JsonReader, value: var Stuint[256])
       value = intVal.stuint(256)
     except:
       raise newException(SerializationError, "Expected string or int representation of Stuint[256]")
+
+type
+  Network* {.pure.} = enum
+    Mainnet,
+    Testnet
+
+  Setting* {.pure.} = enum
+    Appearance = "appearance",
+    Currency = "currency,"
+    InstallationId = "installation-id"
+    Mnemonic = "mnemonic",
+    Networks_CurrentNetwork = "networks/current-network",
+    NodeConfig = "node-config",
+    PublicKey = "public-key",
+    Stickers_PacksInstalled = "stickers/packs-installed",
+    Stickers_Recent = "stickers/recent-stickers"

--- a/src/status/libstatus/utils.nim
+++ b/src/status/libstatus/utils.nim
@@ -1,4 +1,4 @@
-import json, types, random, strutils, strformat
+import json, types, random, strutils, strformat, tables
 import stint
 from times import getTime, toUnix, nanosecond
 import accounts/signing_phrases
@@ -45,4 +45,28 @@ proc wei2Eth*(input: Stuint[256]): string =
 
   fmt"{eth}.{leading_zeros}{remainder}"
 
+proc first*(jArray: JsonNode, fieldName, id: string): JsonNode =
+  if jArray == nil:
+    return nil
+  if jArray.kind != JArray:
+    raise newException(ValueError, "Parameter 'jArray' is a " & $jArray.kind & ", but must be a JArray")
+  for child in jArray.getElems:
+    if child{fieldName}.getStr == id:
+      return child
 
+proc any*(jArray: JsonNode, fieldName, id: string): bool =
+  if jArray == nil:
+    return false
+  result = false
+  for child in jArray.getElems:
+    if child{fieldName}.getStr == id:
+      return true
+
+proc isEmpty*(a: JsonNode): bool =
+  case a.kind:
+  of JObject: return a.fields.len == 0
+  of JArray: return a.elems.len == 0
+  of JString: return a.str == ""
+  of JNull: return true
+  else:
+    return false

--- a/src/status/libstatus/wallet.nim
+++ b/src/status/libstatus/wallet.nim
@@ -80,7 +80,7 @@ proc sendTransaction*(from_address: string, to: string, assetAddress: string, va
       # TODO get decimals from the token
       bigIntValue = bigIntValue * u256(1000000000000000000)
       # Just using mainnet SNT to get the method ABI
-      let contract = getContract(Network.Mainnet, "snt")
+      let contract = getContract("snt")
       let transferEncoded = contract.methods["transfer"].encodeAbi(parseAddress(to), bigIntValue.toHex())
       
       args = %* {

--- a/src/status/status.nim
+++ b/src/status/status.nim
@@ -3,6 +3,7 @@ import eventemitter
 import libstatus/accounts as libstatus_accounts
 import libstatus/core as libstatus_core
 import libstatus/settings as libstatus_settings
+import libstatus/types as libstatus_types
 
 import chat as chat
 import accounts as accounts
@@ -58,5 +59,5 @@ proc reset*(self: Status) =
 proc getNodeVersion*(self: Status): string =
   libstatus_settings.getWeb3ClientVersion()
 
-proc saveSetting*(self: Status, setting: string, value: string) =
-  discard libstatus_settings.saveSettings(setting, value)
+proc saveSetting*(self: Status, setting: Setting, value: string) =
+  discard libstatus_settings.saveSetting(setting, value)

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -5,7 +5,7 @@ import libstatus/tokens as status_tokens
 import libstatus/settings as status_settings
 import libstatus/wallet as status_wallet
 import libstatus/accounts/constants as constants
-from libstatus/types import GeneratedAccount, DerivedAccount, Transaction
+from libstatus/types import GeneratedAccount, DerivedAccount, Transaction, Setting
 import wallet/balance_manager
 import wallet/account
 import wallet/collectibles
@@ -50,10 +50,10 @@ proc sendTransaction*(self: WalletModel, from_value: string, to: string, assetAd
 proc getDefaultCurrency*(self: WalletModel): string =
   # TODO: this should come from a model? It is going to be used too in the
   # profile section and ideally we should not call the settings more than once
-  status_settings.getSetting[string]("currency", "")
+  status_settings.getSetting[string](Setting.Currency, "usd")
 
 proc setDefaultCurrency*(self: WalletModel, currency: string) =
-  discard status_settings.saveSettings("currency", currency)
+  discard status_settings.saveSetting(Setting.Currency, currency)
   self.events.emit("currencyChanged", CurrencyArgs(currency: currency))
 
 proc generateAccountConfiguredAssets*(self: WalletModel, accountAddress: string): seq[Asset] =

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -69,7 +69,7 @@ proc getCryptoKitties*(address: EthAddress): seq[Collectible] =
 proc getEthermons*(address: EthAddress): seq[Collectible] =
   result = @[]
   try:
-    let contract = getContract(Network.Mainnet, "ethermon")
+    let contract = getContract("ethermon")
     let tokens = tokensOfOwnerByIndex(contract, address)
 
     if (tokens.len == 0):
@@ -93,7 +93,7 @@ proc getEthermons*(address: EthAddress): seq[Collectible] =
 proc getKudos*(address: EthAddress): seq[Collectible] =
   result = @[]
   try:
-    let contract = getContract(Network.Mainnet, "kudos")
+    let contract = getContract("kudos")
     let tokens = tokensOfOwnerByIndex(contract, address)
 
     if (tokens.len == 0):

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
@@ -76,6 +76,7 @@ Rectangle {
 
     ChatButtons {
         id: sendBtns
+        height: parent.height
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
         addToChat: function (text) {

--- a/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
@@ -119,6 +119,7 @@ Item {
     }
 
     RowLayout {
+    	id: displayImageSettings
         anchors.top: nodeTabSettings.bottom
         anchors.topMargin: 20
         anchors.left: parent.left
@@ -134,6 +135,29 @@ Item {
         }
         StyledText {
             text: qsTr("under development")
+        }
+    }
+    
+    RowLayout {
+        id: networkTabSettings
+        anchors.top: displayImageSettings.bottom
+        anchors.topMargin: 20
+        anchors.left: parent.left
+        anchors.leftMargin: 24
+        StyledText {
+            text: qsTr("Enable testnet (Ropsten)\nCurrent network: %1").arg(profileModel.network)
+        }
+        Switch {
+            checked: profileModel.network === "testnet_rpc"
+            onCheckedChanged: {
+                if (checked && profileModel.network === "testnet_rpc" || !checked && profileModel.network === "mainnet_rpc"){
+                    return;
+                }
+                profileModel.network = checked ? "testnet_rpc" : "mainnet_rpc";
+            }
+        }
+        StyledText {
+            text: qsTr("Under development\nNOTE: You will be logged out and all installed\nsticker packs will be removed and will\nneed to be reinstalled. Purchased sticker\npacks will not need to be re-purchased.")
         }
     }
 }


### PR DESCRIPTION
Fixes #555 

Allow switching to Ropsten by flipping a toggle switch in Profile > Advanced settings.

When switching networks, note that installed stickers will be uninstalled, and recent stickers will be removed. Sticker packs can be reinstalled after login. Purchased sticker packs will not need to be re-purchased, but will need to be re-installed.

Mailserver fleet information will **not** be updated. This can be controlled by a separate (undeveloped yet) setting.

**NOTE**
This PR is based off of https://github.com/status-im/nim-status-client/pull/550, and should be rebased only after it is merged. 
https://github.com/status-im/nim-status-client/pull/545 > https://github.com/status-im/nim-status-client/pull/550 > This PR