### PR TITLE
build: implement packaging steps for the Windows build

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -23,6 +23,7 @@ if defined(macosx):
   # set the minimum supported macOS version to 10.13
   switch("passC", "-mmacosx-version-min=10.13")
 elif defined(windows):
+  --app:gui
   --tlsEmulation:off
   switch("passL", "-Wl,-as-needed")
 else:

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -25,9 +25,19 @@ proc mainProc() =
   initializeOpenGL()
 
   let app = newQApplication("Nim Status Client")
-  QResource.registerResource(app.applicationDirPath & "/../resources.rcc")
+  let resources =
+    if defined(windows) and getEnv("NIM_STATUS_CLIENT_DEV").string == "":
+      "/../resources/resources.rcc"
+    else:
+      "/../resources.rcc"
+  QResource.registerResource(app.applicationDirPath & resources)
 
-  app.icon(app.applicationDirPath & "/../status.svg")
+  let statusSvg =
+    if defined(windows) and getEnv("NIM_STATUS_CLIENT_DEV").string == "":
+        "/../resources/status.svg"
+      else:
+        "/../status.svg"
+  app.icon(app.applicationDirPath & statusSvg)
 
   let engine = newQQmlApplicationEngine()
   let signalController = signals.newController(app)
@@ -54,7 +64,7 @@ proc mainProc() =
     profile.init(args.account)
     wallet.init()
     chat.init()
-    
+
 
   var login = login.newController(status)
   var onboarding = onboarding.newController(status)
@@ -84,7 +94,7 @@ proc mainProc() =
     node.init()
     login.init()
     onboarding.init()
-  
+
   initControllers()
 
   # Handle node.stopped signal when user has logged out
@@ -100,7 +110,7 @@ proc mainProc() =
     # node.reset()
     # wallet.reset()
     # profile.reset()
-    
+
     # 2. Re-init controllers that don't require a running node
     initControllers()
 

--- a/src/nim_windows_launcher.nim
+++ b/src/nim_windows_launcher.nim
@@ -1,0 +1,17 @@
+from os import getCurrentDir, joinPath
+from winlean import Handle, shellExecuteW
+
+const NULL: Handle = 0
+let cwd = getCurrentDir()
+let workDir_str = joinPath(cwd, "bin")
+let exePath_str = joinPath(workDir_str, "Status.exe")
+let open_str = "open"
+let params_str = ""
+let workDir = newWideCString(workDir_str)
+let exePath = newWideCString(exePath_str)
+let open = newWideCString(open_str)
+let params = newWideCString(params_str)
+# SW_SHOW (5): activates window and displays it in its current size and position
+const showCmd: int32 = 5
+
+discard shellExecuteW(NULL, open, exePath, params, workDir, showCmd)

--- a/windows-install.txt
+++ b/windows-install.txt
@@ -1,0 +1,42 @@
+REQUIREMENTS
+============
+
+This application requires 64-bit Windows 7 or newer.
+
+INSTALLING
+==========
+
+After unzipping Status.zip, the Status folder can be placed wherever you prefer
+(and have permissions) on your computer.
+
+RUNNING
+=======
+
+Double-click Status.exe in the Status folder to launch the application.
+
+If you see an error complaining about a DLL file, you should open
+vc_redist.x64.exe in the Status\vendor folder to install the Microsoft Visual
+C++ Redistributable. This is usually necessary only on versions of Windows
+older than Windows 10. Then retry launching the application.
+
+You may wish to right-click Status.exe and "Send to > Desktop (create shortcut)".
+The application can then be launched by double-clicking the shortcut on your
+desktop.
+
+Status.exe persists settings and encrypted data in your %LOCALAPPDATA%\Status
+folder.
+
+UPGRADING
+=========
+
+To upgrade this application download the latest Status.zip, delete this Status
+folder and the older Status.zip, unzip the newer one, and then place the new
+Status folder in your preferred location.
+
+If you place the new Status folder in a different location than the old one
+then you should recreate any shortcuts you created for Status.exe.
+
+UNINSTALLING
+============
+
+Delete this Status folder and delete your %LOCALAPPDATA%\Status folder.


### PR DESCRIPTION
Implement a `pkg-windows` target that ultimately results in `Status.zip` being written to `pkg/`.

Note: this commit does not introduce code signing for the Windows build since that piece is still a work in progress.

`pkg-windows` creates a portable folder in `tmp/windows/dist` with the help of [`windeployqt`][windeployqt], which copies the needed portions of Qt into the folder.

Since DLL resolution is relatively inflexible, a launcher `Status.exe` is created at the top-level of the folder; the launcher opens `bin/Status.exe` while adding the portable folder's `bin/` to the `PATH`, allowing `bin/Status.exe` to resolve the DLLs in that folder.

A few additional tools need to be installed (e.g. with [scoop][scoop]) and availble in `PATH`:
* 7-zip
* dos2unix (provides unix2dos)
* findutils
* go
* rcedit
* wget

The above list builds on the tools list in PR #521, and the other requirements and instructions in that PR's description still apply.

**Why not build an installer?**

When starting work on packaging for the Windows build, my initial plan was to build an installer, and for that purpose I researched the [WiX Toolset][wix], the [Qt Installer Framework][qtif], and some other options.

I found that building an installer is a bit complex. I then recalled, from personal experience, that [Cmder][cmder]’s [Mini download][mini] is installer-less. You simply unzip the download and place the `cmder_mini` folder wherever you prefer. Such an approach was also recommended to me in one of the Nim language's community chats.

In addition to being simpler, the installer-less approach also gives installation of Status Desktop a lower profile than an installer-application would since nothing is written to the Windows registry, added to the *Add or remove programs* list, etc. I think that's a benefit given the privacy-security focus of Status, but others may feel differently so please provide feedback on this point!

[windeployqt]: https://doc.qt.io/qt-5/windows-deployment.html
[scoop]: https://scoop.sh/
[wix]: https://wixtoolset.org/
[qtif]: https://doc.qt.io/qtinstallerframework/index.html
[cmder]: https://cmder.net/
[mini]: https://github.com/cmderdev/cmder/releases/download/v1.3.15/cmder_mini.zip