### PR TITLE
Fix message UI issues

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -224,6 +224,7 @@ QtObject:
 
   proc joinChat*(self: ChatsView, channel: string, chatTypeInt: int): int {.slot.} =
     self.status.chat.join(channel, ChatType(chatTypeInt))
+    self.setActiveChannel(channel)
 
   proc joinGroup*(self: ChatsView) {.slot.} =
     self.status.chat.confirmJoiningGroup(self.activeChannel.id)

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
@@ -35,6 +35,7 @@ Rectangle {
         wrapMode: Text.Wrap
         anchors.left: parent.left
         anchors.right: chatReply.longReply ? parent.right : undefined
+        z: 51
     }
 
     Separator {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
@@ -3,6 +3,9 @@ import "../../../../../shared"
 import "../../../../../imports"
 
 Rectangle {
+    property alias textField: lblReplyMessage
+    property bool longReply: false
+
     id: chatReply
     color:  Style.current.lightBlue
     visible: responseTo != "" && replyMessageIndex > -1
@@ -31,7 +34,7 @@ Rectangle {
         selectByMouse: true
         wrapMode: Text.Wrap
         anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.right: chatReply.longReply ? parent.right : undefined
     }
 
     Separator {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -12,6 +12,21 @@ StyledTextEdit {
     readOnly: true
     selectByMouse: true
     color: Style.current.textColor
+    z: 51
+    onLinkActivated: function (link) {
+        if(link.startsWith("#")){
+            chatsModel.joinChat(link.substring(1), Constants.chatTypePublic);
+            return;
+        }
+
+        if (link.startsWith('//')) {
+          let pk = link.replace("//", "");
+          profileClick(chatsModel.userNameOrAlias(pk), pk, chatsModel.generateIdenticon(pk))
+          return;
+        }
+
+        Qt.openUrlExternally(link)
+    }
     text: {
         if(contentType === Constants.stickerType) return "";
         let msg = Utils.linkifyAndXSS(message);
@@ -44,6 +59,5 @@ StyledTextEdit {
                 `</body>`+
             `</html>`;
         }
-
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -6,44 +6,44 @@ StyledTextEdit {
     id: chatText
     visible: contentType == Constants.messageType || isEmoji
     textFormat: Text.RichText
-    text: {
-        if(contentType === Constants.stickerType) return "";
-        let msg = Utils.linkifyAndXSS(message);
-        if(isEmoji){
-            return Emoji.parse(msg, "72x72");
-        } else {
-            return `<html>
-                <head>
-                    <style type="text/css">
-                    code {
-                        background-color: #1a356b;
-                        color: #FFFFFF;
-                        white-space: pre;
-                    }
-                    p {
-                        white-space: pre;
-                    }
-                    a.mention {
-                        color: ${isCurrentUser ? Style.current.black : Style.current.white}
-                        font-weight: bold;
-                    }
-                    blockquote {
-                        margin: 0;
-                        padding: 0;
-                    }
-                    </style>
-                </head>
-                <body>
-                    ${Emoji.parse(msg, "26x26")}
-                </body>
-            </html>`;
-        }
-
-    }
     horizontalAlignment: Text.AlignLeft
     wrapMode: Text.Wrap
     font.pixelSize: 15
     readOnly: true
     selectByMouse: true
     color: Style.current.textColor
+    text: {
+        if(contentType === Constants.stickerType) return "";
+        let msg = Utils.linkifyAndXSS(message);
+        if(isEmoji){
+            return Emoji.parse(msg, "72x72");
+        } else {
+            return `<html>`+
+                `<head>`+
+                    `<style type="text/css">`+
+                    `code {`+
+                        `background-color: #1a356b;`+
+                        `color: #FFFFFF;`+
+                        `white-space: pre;`+
+                    `}`+
+                    `p {`+
+                        `white-space: pre-wrap;`+
+                    `}`+
+                    `a.mention {`+
+                        `color: ${isCurrentUser ? Style.current.black : Style.current.white};`+
+                        `font-weight: bold;`+
+                    `}`+
+                    `blockquote {`+
+                        `margin: 0;`+
+                        `padding: 0;`+
+                    `}`+
+                    `</style>`+
+                `</head>`+
+                `<body>`+
+                    `${Emoji.parse(msg, "26x26")}`+
+                `</body>`+
+            `</html>`;
+        }
+
+    }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
@@ -3,27 +3,14 @@ import "../../../../../shared"
 import "../../../../../imports"
 
 MouseArea {
-    cursorShape: chatText.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    cursorShape: chatText.hoveredLink ? Qt.PointingHandCursor : undefined
+    acceptedButtons: Qt.RightButton
+    z: 50
     onClicked: {
         if(mouse.button & Qt.RightButton) {
             clickMessage()
             return;
         }
-
-        let link = chatText.hoveredLink;
-        if(link.startsWith("#")){
-            chatsModel.joinChat(link.substring(1), Constants.chatTypePublic);
-            return;
-        }
-
-        if (link.startsWith('//')) {
-          let pk = link.replace("//", "");
-          profileClick(chatsModel.userNameOrAlias(pk), pk, chatsModel.generateIdenticon(pk))
-          return;
-        }
-
-        Qt.openUrlExternally(link)
     }
 }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -38,6 +38,8 @@ Item {
     Rectangle {
         property int chatVerticalPadding: 7
         property int chatHorizontalPadding: 12
+        property bool longReply: chatReply.visible && repliedMessageContent.length > 54
+        property bool longChatText: plainText.length > 54
 
         id: chatBox
         color: isSticker ? Style.current.background  : (isCurrentUser ? Style.current.blue : Style.current.secondaryBackground)
@@ -49,7 +51,14 @@ Item {
                 case Constants.stickerType:
                     return stickerId.width + (2 * chatBox.chatHorizontalPadding);
                 default:
-                    return plainText.length > 54 ? 400 : chatText.width + 2 * chatHorizontalPadding
+                    if (longChatText || longReply) {
+                        return 400;
+                    }
+                    let baseWidth = chatText.width;
+                    if (chatReply.visible && chatText.width < chatReply.textField.width) {
+                        baseWidth = chatReply.textField.width
+                    }
+                    return baseWidth + 2 * chatHorizontalPadding
             }
         }
 
@@ -64,6 +73,7 @@ Item {
 
         ChatReply {
             id: chatReply
+            longReply: chatBox.longReply
             anchors.top: parent.top
             anchors.topMargin: chatReply.visible ? chatBox.chatVerticalPadding : 0
             anchors.left: parent.left
@@ -79,9 +89,9 @@ Item {
             anchors.top: chatReply.bottom
             anchors.topMargin: chatBox.chatVerticalPadding
             anchors.left: parent.left
-            anchors.leftMargin: parent.chatHorizontalPadding
-            anchors.right: plainText.length > 52 ? parent.right : undefined
-            anchors.rightMargin: plainText.length > 52 ? parent.chatHorizontalPadding : 0
+            anchors.leftMargin: chatBox.chatHorizontalPadding
+            anchors.right: chatBox.longChatText ? parent.right : undefined
+            anchors.rightMargin: chatBox.longChatText ? chatBox.chatHorizontalPadding : 0
             horizontalAlignment: !isCurrentUser ? Text.AlignLeft : Text.AlignRight
             color: !isCurrentUser ? Style.current.textColor : Style.current.currentUserTextColor
         }
@@ -89,7 +99,7 @@ Item {
         Sticker {
             id: stickerId
             anchors.left: parent.left
-            anchors.leftMargin: parent.chatHorizontalPadding
+            anchors.leftMargin: chatBox.chatHorizontalPadding
             anchors.top: parent.top
             anchors.topMargin: chatBox.chatVerticalPadding
         }


### PR DESCRIPTION
Fixes #605 

- Fix text overflowing out of the balloon
  - This was caused by the `white-space` css property. Without `pre`, using `SHIFT+ENTER`, there were no line breaks, but with `pre`, the auto wrap didn't work. The solution was switching to `pre-wrap`.
- Fix replies being squished
  - Happened when the reply was smaller than the message being replied to. 
  - Now it takes the bigger text as the width
- Fix text selection
  - Was caused by the MouseArea being on top, eating all the click
  - Putting it right under the text fixes it, but broke the link clicking, so I moved the link clicking to the Text itself. So the MouseArea only handles right clciks.