### PR TITLE
fix: fix chat list scrolling down when user was looking up the chats

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -295,8 +295,6 @@ QtObject:
       if(self.activeChannel.id == chat.id):
         self.activeChannel.setChatItem(chat)
         self.currentSuggestions.setNewData(self.status.contacts.getContacts())
-        if triggerChange: 
-          self.activeChannelChanged()
     self.calculateUnreadMessages()
 
   proc renameGroup*(self: ChatsView, newName: string) {.slot.} =


### PR DESCRIPTION
Replaces https://github.com/status-im/nim-status-client/pull/642
Fixes #286

@richard-ramos please check if it might break something. I know you changed it a bit recently.
Basically, I think that call doesn't belong there, that signal should only be called when we change the active channel, which we do above in the code. Otherwise, we end up scrolling down with force on new messages 