### PR TITLE
fix: Dark mode fixes

### DIFF
--- a/src/app/wallet/views/account_list.nim
+++ b/src/app/wallet/views/account_list.nim
@@ -1,9 +1,11 @@
-import NimQml, Tables, random
+import NimQml, Tables, random, strformat, json_serialization
 import sequtils as sequtils
-import account_item
+import account_item, asset_list
 from ../../../status/wallet import WalletAccount
 
 const accountColors* = ["#9B832F", "#D37EF4", "#1D806F", "#FA6565", "#7CDA00", "#887af9", "#8B3131"]
+type
+  AccountView* = tuple[account: WalletAccount, assets: AssetList]
 
 type
   AccountRoles {.pure.} = enum
@@ -11,10 +13,12 @@ type
     Address = UserRole + 2,
     Color = UserRole + 3,
     Balance = UserRole + 4
+    FiatBalance = UserRole + 5
+    Assets = UserRole + 6
 
 QtObject:
   type AccountList* = ref object of QAbstractListModel
-    accounts*: seq[WalletAccount]
+    accounts*: seq[AccountView]
 
   proc setup(self: AccountList) = self.QAbstractListModel.setup
 
@@ -27,12 +31,14 @@ QtObject:
     result.accounts = @[]
     result.setup
   
-  proc getAccount*(self: AccountList, index: int): WalletAccount = self.accounts[index]
+  proc getAccount*(self: AccountList, index: int): WalletAccount = self.accounts[index].account
 
   proc rowData(self: AccountList, index: int, column: string): string {.slot.} =
     if (index >= self.accounts.len):
       return
-    let account = self.accounts[index]
+    let
+      accountView = self.accounts[index]
+      account = accountView.account
     case column:
       of "name": result = account.name
       of "address": result = account.address
@@ -40,11 +46,13 @@ QtObject:
       of "balance": result = account.balance
       of "path": result = account.path
       of "walletType": result = account.walletType
+      of "fiatBalance": result = fmt"{account.realFiatBalance:>.2f}"
+      # of "assets": result = Json.encode(accountView.assets)
 
   proc getAccountindexByAddress*(self: AccountList, address: string): int =
     var i = 0
-    for account in self.accounts:
-      if (account.address == address):
+    for accountView in self.accounts:
+      if (accountView.account.address == address):
         return i
       i = i + 1
     return -1
@@ -60,26 +68,33 @@ QtObject:
       return
     if index.row < 0 or index.row >= self.accounts.len:
       return
-    let account = self.accounts[index.row]
+    let accountView = self.accounts[index.row]
+    let account = accountView.account
     let accountRole = role.AccountRoles
     case accountRole:
     of AccountRoles.Name: result = newQVariant(account.name)
     of AccountRoles.Address: result = newQVariant(account.address)
     of AccountRoles.Color: result = newQVariant(account.iconColor)
     of AccountRoles.Balance: result = newQVariant(account.balance)
+    of AccountRoles.FiatBalance: result = newQVariant(fmt"{account.realFiatBalance:>.2f}")
+    of AccountRoles.Assets: result = newQVariant(accountView.assets)
 
   method roleNames(self: AccountList): Table[int, string] =
     { AccountRoles.Name.int:"name",
     AccountRoles.Address.int:"address",
     AccountRoles.Color.int:"iconColor",
-    AccountRoles.Balance.int:"balance" }.toTable
+    AccountRoles.Balance.int:"balance",
+    AccountRoles.FiatBalance.int:"fiatBalance",
+    AccountRoles.Assets.int:"assets" }.toTable
 
   proc addAccountToList*(self: AccountList, account: WalletAccount) =
     if account.iconColor == "":
       randomize()
       account.iconColor = accountColors[rand(accountColors.len - 1)]
+    let assets = newAssetList()
+    assets.setNewData(account.assetList)
     self.beginInsertRows(newQModelIndex(), self.accounts.len, self.accounts.len)
-    self.accounts.add(account)
+    self.accounts.add((account: account, assets: assets))
     self.endInsertRows()
 
   proc forceUpdate*(self: AccountList) =

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -72,7 +72,7 @@ StackLayout {
                 id: connectedStatusRect
                 Layout.fillWidth: true
                 height: 40;
-                color: isConnected ? Style.current.green : Style.current.darkGrey
+                color: isConnected ? Style.current.green : Style.current.grey
                 visible: false
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatButtons.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatButtons.qml
@@ -44,7 +44,7 @@ Item {
             chatColumn.hideExtendedArea();
         }
         background: Rectangle {
-            color: parent.enabled ? Style.current.blue : Style.current.grey
+            color: parent.enabled ? Style.current.blue : Style.current.lightGrey
             radius: 50
         }
         SVGImage {
@@ -85,7 +85,7 @@ Item {
         ColorOverlay {
             anchors.fill: emojiIcon
             source: emojiIcon
-            color: emojiIconContainer.hovered || emojiPopup.opened ? Style.current.blue : Style.current.darkGrey
+            color: emojiIconContainer.hovered || emojiPopup.opened ? Style.current.blue : Style.current.grey
         }
 
         MouseArea {
@@ -134,7 +134,7 @@ Item {
         ColorOverlay {
             anchors.fill: stickersIcon
             source: stickersIcon
-            color: stickerIconContainer.hovered || stickersPopup.opened ? Style.current.blue : Style.current.darkGrey
+            color: stickerIconContainer.hovered || stickersPopup.opened ? Style.current.blue : Style.current.grey
         }
 
         MouseArea {
@@ -182,7 +182,7 @@ Item {
         ColorOverlay {
             anchors.fill: imageIcon
             source: imageIcon
-            color: imageIconContainer.hovered ? Style.current.blue : Style.current.darkGrey
+            color: imageIconContainer.hovered ? Style.current.blue : Style.current.grey
         }
 
         MouseArea {

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -71,7 +71,7 @@ ScrollView {
                 anchors.top: newMessagesText.bottom
                 anchors.topMargin: 0
                 font.pixelSize: 12
-                color: Style.current.darkGrey
+                color: Style.current.grey
             }
 
             MouseArea {

--- a/ui/app/AppLayouts/Chat/ChatColumn/EmptyChat.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/EmptyChat.qml
@@ -33,7 +33,7 @@ Item {
         anchors.left: walkieTalkieImage.left
         anchors.top: walkieTalkieImage.bottom
         font.pixelSize: 15
-        color: Style.current.darkGrey
+        color: Style.current.grey
         onLinkActivated: function (linkClicked) {
             switch (linkClicked) {
                 case "shareKey":

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -93,7 +93,7 @@ Item {
             text:  message
             visible: isStatusMessage
             font.pixelSize: 16
-            color: Style.current.darkGrey
+            color: Style.current.grey
             width:  parent.width - 120
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
@@ -15,7 +15,7 @@ Rectangle {
     StyledTextEdit {
         id: lblReplyAuthor
         text: "↳" + repliedMessageAuthor
-        color: Style.current.darkGrey
+        color: Style.current.grey
         readOnly: true
         selectByMouse: true
         wrapMode: Text.Wrap
@@ -41,7 +41,7 @@ Rectangle {
         anchors.topMargin: 5
         text: Emoji.parse(Utils.linkifyAndXSS(repliedMessageContent), "26x26");
         textFormat: Text.RichText
-        color: Style.current.darkGrey
+        color: Style.current.grey
         readOnly: true
         selectByMouse: true
         wrapMode: Text.Wrap
@@ -56,6 +56,6 @@ Rectangle {
         anchors.left: lblReplyMessage.left
         anchors.right: lblReplyMessage.right
         anchors.rightMargin: chatTextItem.chatHorizontalPadding
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
@@ -5,7 +5,7 @@ import "../../../../../imports"
 StyledTextEdit {
     id: chatTime
     visible: isMessage
-    color: Style.current.darkGrey
+    color: Style.current.grey
     text: {
         let messageDate = new Date(Math.floor(timestamp))
         let minutes = messageDate.getMinutes();

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -78,7 +78,7 @@ Item {
         id: stickerContainer
         visible: contentType === Constants.stickerType
         color: Style.current.transparent
-        border.color: Style.current.grey
+        border.color: Style.current.lightGrey
         border.width: 1
         radius: 16
         width: stickerId.width

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/DateGroup.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/DateGroup.qml
@@ -5,7 +5,7 @@ import "../../../../../imports"
 StyledText {
     id: dateGroupLbl
     font.pixelSize: 13
-    color: Style.current.darkGrey
+    color: Style.current.grey
     horizontalAlignment: Text.AlignHCenter
     anchors.horizontalCenter: parent.horizontalCenter
     text: {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/SentMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/SentMessage.qml
@@ -5,7 +5,7 @@ import "../../../../../imports"
 StyledText {
     id: sentMessage
     visible: isCurrentUser && !timeout && !isExpired && isMessage
-    color: Style.current.darkGrey
+    color: Style.current.grey
     text: outgoingStatus === "sent" ?
     //% "Sent"
     qsTrId("status-sent") :

--- a/ui/app/AppLayouts/Chat/ChatColumn/ReplyArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ReplyArea.qml
@@ -60,7 +60,7 @@ Rectangle {
                 closeButton.color = Style.current.white
             }
             onEntered: {
-                closeButton.color = Style.current.grey
+                closeButton.color = Style.current.lightGrey
             }
             onClicked: {
                 chatColumn.hideExtendedArea()

--- a/ui/app/AppLayouts/Chat/ChatColumn/SendImageArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/SendImageArea.qml
@@ -44,7 +44,7 @@ Rectangle {
                 closeButton.color = Style.current.white
             }
             onEntered: {
-                closeButton.color = Style.current.grey
+                closeButton.color = Style.current.lightGrey
             }
             onClicked: {
                 chatColumn.hideExtendedArea();

--- a/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
@@ -44,7 +44,7 @@ Rectangle {
 
     StyledText {
         id: channelIdentifier
-        color: Style.current.darkGrey
+        color: Style.current.grey
         text: {
             switch(chatsModel.activeChannel.chatType){
                 //% "Public chat"

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -97,7 +97,7 @@ Rectangle {
         font.pixelSize: 15
         anchors.left: contactImage.right
         anchors.leftMargin: Style.current.padding
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 
     StyledText {
@@ -144,7 +144,7 @@ Rectangle {
             anchors.topMargin: !isCompact ? Style.current.smallPadding : 0
             anchors.verticalCenter: !isCompact ? undefined : parent.verticalCenter
             font.pixelSize: 11
-            color: Style.current.darkGrey
+            color: Style.current.grey
     }
     Rectangle {
         id: contactNumberChatsCircle

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ClosedEmptyView.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ClosedEmptyView.qml
@@ -23,7 +23,7 @@ Item {
         anchors.leftMargin: 56
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 15
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 }
 

--- a/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
@@ -58,7 +58,7 @@ Item {
             ColorOverlay {
                 anchors.fill: closeImg
                 source: closeImg
-                color: Style.current.darkGrey
+                color: Style.current.grey
             }
             MouseArea {
                 anchors.fill: closeImg

--- a/ui/app/AppLayouts/Chat/components/Contact.qml
+++ b/ui/app/AppLayouts/Chat/components/Contact.qml
@@ -90,7 +90,7 @@ Rectangle {
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
         font.pixelSize: 15
-        color: Style.current.darkGrey
+        color: Style.current.grey
         anchors.top: accountImage.top
         anchors.topMargin: 10
     }

--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -73,7 +73,7 @@ ModalPopup {
           anchors.top: lblNewGroup.bottom
           //% "%1 / 10 members"
           text: qsTrId("%1-/-10-members").arg(memberCount)
-          color: Style.current.darkGrey
+          color: Style.current.grey
           font.pixelSize: 15
       }
     }

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -105,7 +105,7 @@ ModalPopup {
           anchors.top: groupName.bottom
           anchors.topMargin: 2
           font.pixelSize: 14
-          color: Style.current.darkGrey
+          color: Style.current.grey
       }
 
       Rectangle {
@@ -135,7 +135,7 @@ ModalPopup {
                     editGroupNameBtn.color = Style.current.white
                 }
                 onEntered: {
-                    editGroupNameBtn.color = Style.current.grey
+                    editGroupNameBtn.color = Style.current.lightGrey
                 }
                 onClicked: renameGroupPopup.open()
             }
@@ -217,7 +217,7 @@ ModalPopup {
             anchors.left: parent.left
             anchors.leftMargin: Style.current.padding
             font.pixelSize: 15
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
 
         ListModel {

--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -90,7 +90,7 @@ ModalPopup {
         id: ensUsername
         anchors.top: chatKey.bottom
         anchors.topMargin: Style.current.padding
-        color: Style.current.darkGrey
+        color: Style.current.grey
         font.pixelSize: 12
     }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -73,7 +73,7 @@ ModalPopup {
             anchors.top: profileName.bottom
             anchors.topMargin: 2
             font.pixelSize: 14
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
 
         Rectangle {
@@ -102,7 +102,7 @@ ModalPopup {
                     qrCodeButton.color = Style.current.white
                 }
                 onEntered: {
-                    qrCodeButton.color = Style.current.grey
+                    qrCodeButton.color = Style.current.lightGrey
                 }
                 onClicked: {
                     showQR = true
@@ -139,7 +139,7 @@ ModalPopup {
             text: qsTrId("ens-username")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
+            color: Style.current.grey
             anchors.left: parent.left
             anchors.leftMargin: Style.current.smallPadding
             anchors.top: parent.top
@@ -173,7 +173,7 @@ ModalPopup {
             text: qsTrId("chat-key")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
+            color: Style.current.grey
             anchors.left: parent.left
             anchors.leftMargin: Style.current.smallPadding
             anchors.top: isEnsVerified ? valueEnsName.bottom : parent.top
@@ -215,7 +215,7 @@ ModalPopup {
             text: qsTrId("share-profile-url")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
+            color: Style.current.grey
             anchors.left: parent.left
             anchors.leftMargin: Style.current.smallPadding
             anchors.top: separator.bottom
@@ -266,7 +266,7 @@ ModalPopup {
             anchors.rightMargin: addToContactsButton.width + 32
             btnColor: "white"
             btnBorderWidth: 1
-            btnBorderColor: Style.current.grey
+            btnBorderColor: Style.current.lightGrey
             textColor: Style.current.red
             //% "Block User"
             label: qsTrId("block-user")

--- a/ui/app/AppLayouts/Chat/components/StickerButton.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerButton.qml
@@ -83,8 +83,8 @@ Item {
             PropertyChanges {
                 target: root;
                 text: root.style === StickerButton.StyleType.Default ? packPrice : packPrice + " SNT";
-                textColor: root.style === StickerButton.StyleType.Default ? Style.current.white : Style.current.darkGrey
-                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.darkGrey : Style.current.grey;
+                textColor: root.style === StickerButton.StyleType.Default ? Style.current.white : Style.current.grey
+                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.grey : Style.current.lightGrey;
                 enabled: false;
             }
         },
@@ -95,8 +95,8 @@ Item {
                 target: root;
                 //% "Pending..."
                 text: qsTrId("pending---");
-                textColor: root.style === StickerButton.StyleType.Default ? Style.current.white : Style.current.darkGrey
-                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.darkGrey : Style.current.grey;
+                textColor: root.style === StickerButton.StyleType.Default ? Style.current.white : Style.current.grey
+                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.grey : Style.current.lightGrey;
                 enabled: false;
                 icon: new Object({
                     path: "../../../img/loading.png",
@@ -114,7 +114,7 @@ Item {
                 //% "Cancel"
                 text: qsTrId("browsing-cancel");
                 textColor: root.style === StickerButton.StyleType.Default ? Style.current.white : Style.current.red;
-                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.darkGrey : Style.current.lightRed;
+                bgColor: root.style === StickerButton.StyleType.Default ? Style.current.grey : Style.current.lightRed;
             }
         },
         State {

--- a/ui/app/AppLayouts/Chat/components/StickerPackDetails.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerPackDetails.qml
@@ -34,7 +34,7 @@ Item {
             font.pixelSize: packNameFontSize
         }
         Text {
-            color: Style.current.darkGrey
+            color: Style.current.grey
             text: packAuthor
             font.family: Style.current.fontRegular.name
             font.pixelSize: 15

--- a/ui/app/AppLayouts/Chat/components/StickerPackIconWithIndicator.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerPackIconWithIndicator.qml
@@ -28,7 +28,7 @@ Item {
         width: parent.width
         height: parent.height
         iconWidth: 6
-        color: Style.current.darkGrey
+        color: Style.current.grey
         source: root.source
         onClicked: {
             root.clicked()

--- a/ui/app/AppLayouts/Node/NodeLayout.qml
+++ b/ui/app/AppLayouts/Node/NodeLayout.qml
@@ -85,7 +85,7 @@ Item {
                         }
                         enabled: txtData.text !== ""
                         background: Rectangle {
-                            color: parent.enabled ? Style.current.blue : Style.current.grey
+                            color: parent.enabled ? Style.current.blue : Style.current.lightGrey
                             radius: 50
                         }
                     }

--- a/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
@@ -56,7 +56,7 @@ ModalPopup {
             StyledText {
               id: count
               text: index+1
-              color: Style.current.darkGrey
+              color: Style.current.grey
               anchors.bottom: parent.bottom
               anchors.bottomMargin: Style.current.smallPadding
               anchors.left: parent.left
@@ -86,7 +86,7 @@ ModalPopup {
       text: qsTrId("with-this-12-words-you-can-always-get-your-key-back.-write-it-down.-keep-it-safe,-offline,-and-separate-from-this-device.")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
       anchors.bottom: parent.bottom
       anchors.bottomMargin: Style.current.padding
       anchors.left: parent.left

--- a/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
@@ -71,7 +71,7 @@ Rectangle {
                 menuButton.color = Style.current.white
             }
             onEntered: {
-                menuButton.color = Style.current.grey
+                menuButton.color = Style.current.lightGrey
             }
             onClicked: {
               menuOpened = true

--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -129,7 +129,7 @@ Item {
               anchors.top: addContactSearchInput.bottom
               anchors.topMargin: Style.current.padding
               font.pixelSize: 12
-              color: Style.current.darkGrey
+              color: Style.current.grey
           }
 
           StyledText {
@@ -139,7 +139,7 @@ Item {
               width: 100
               font.pixelSize: 12
               elide: Text.ElideMiddle
-              color: Style.current.darkGrey
+              color: Style.current.grey
           }
 
         }
@@ -179,7 +179,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             font.pixelSize: 15
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
 
         StyledButton {

--- a/ui/app/AppLayouts/Profile/Sections/LanguageContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/LanguageContainer.qml
@@ -33,20 +33,33 @@ Item {
             text: qsTr("Language")
         }
         Select {
+            id: select
             selectedText: languageSetting.currentLocale
             anchors.right: undefined
             anchors.left: undefined
             width: 100
             Layout.leftMargin: Style.current.padding
-            selectOptions: Locales_JSON.locales.map(locale => {
-                return {
-                    label: locale,
-                    onClicked: function () {
+            model: Locales_JSON.locales
+            menu.delegate: Component {
+                MenuItem {
+                    height: itemText.height + 4
+                    width: parent.width
+                    padding: 10
+                    onTriggered: function () {
+                        const locale = Locales_JSON.locales[index]
                         profileModel.changeLocale(locale)
                         appSettings.locale = locale
                     }
-               }
-            })
+
+                    StyledText {
+                        id: itemText
+                        text: Locales_JSON.locales[index]
+                        anchors.left: parent.left
+                        anchors.leftMargin: 5
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                }
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/MyProfileContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/MyProfileContainer.qml
@@ -65,7 +65,7 @@ Item {
             elide: Text.ElideMiddle
             width: 140
             font.pixelSize: 15
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
 
         SVGImage {

--- a/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
@@ -25,7 +25,7 @@ Item {
             //% "Security"
             text: qsTrId("security")
             font.pixelSize: 15
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
 
         Item {
@@ -55,7 +55,7 @@ Item {
             ColorOverlay {
                 anchors.fill: caret
                 source: caret
-                color: Style.current.darkGrey
+                color: Style.current.grey
                 rotation: -90
             }
 
@@ -79,7 +79,7 @@ Item {
             id: labelPrivacy
             text: qsTr("Privacy")
             font.pixelSize: 15
-            color: Style.current.darkGrey
+            color: Style.current.grey
             anchors.top: separator.bottom
             anchors.topMargin: Style.current.smallPadding
         }

--- a/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
@@ -50,16 +50,43 @@ ModalPopup {
         bgColor: selectedColor
         //% "Account color"
         label: qsTrId("account-color")
-        selectOptions: Constants.accountColors.map(color => {
-            return {
-                text: "",
-                bgColor: color,
-                height: 52,
-                onClicked: function () {
-                    selectedColor = color
+        model: Constants.accountColors
+        menu.delegate: Component {
+            MenuItem {
+                property bool isFirstItem: index === 0
+                property bool isLastItem: index === Constants.accountColors.length - 1
+                height: 52
+                width: parent.width
+                padding: 10
+                onTriggered: function () {
+                    selectedColor = Constants.accountColors[index]
                 }
-           }
-        })
+                background: Rectangle {
+                    color: Constants.accountColors[index]
+                    radius: Style.current.radius
+
+                    // cover bottom left/right corners with square corners
+                    Rectangle {
+                        visible: !isLastItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.radius
+                        color: parent.color
+                    }
+
+                    // cover top left/right corners with square corners
+                    Rectangle {
+                        visible: !isFirstItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: parent.radius
+                        color: parent.color
+                    }
+                }
+            }
+        }
     }
 
     TextWithLabel {

--- a/ui/app/AppLayouts/Wallet/AssetsTab.qml
+++ b/ui/app/AppLayouts/Wallet/AssetsTab.qml
@@ -44,7 +44,7 @@ Item {
                 anchors.bottomMargin: 0
                 anchors.left: assetInfoImage.right
                 anchors.leftMargin: Style.current.smallPadding
-                color: Style.current.darkGrey
+                color: Style.current.grey
                 font.pixelSize: 15
             }
             StyledText {
@@ -57,7 +57,7 @@ Item {
             }
             StyledText {
                 id: assetFiatValue
-                color: Style.current.darkGrey
+                color: Style.current.grey
                 text: fiatValue.toUpperCase()
                 anchors.right: parent.right
                 anchors.rightMargin: 0

--- a/ui/app/AppLayouts/Wallet/CollectiblesTab.qml
+++ b/ui/app/AppLayouts/Wallet/CollectiblesTab.qml
@@ -67,7 +67,7 @@ Item {
                 anchors.leftMargin: Style.current.padding
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: collectibleName.right
-                color: Style.current.darkGrey
+                color: Style.current.grey
                 font.pixelSize: 15
             }
         }

--- a/ui/app/AppLayouts/Wallet/HistoryTab.qml
+++ b/ui/app/AppLayouts/Wallet/HistoryTab.qml
@@ -121,7 +121,7 @@ Item {
           StyledText {
               text: to != walletModel.currentAccount.address ? "To " : "From "
               anchors.right: addressValue.left
-              color: Style.current.darkGrey
+              color: Style.current.grey
               anchors.top: parent.top
               font.pixelSize: 15
               font.strikeout: false
@@ -150,7 +150,7 @@ Item {
               text: "• "
               font.weight: Font.Bold
               anchors.right: timeIndicator.left
-              color: Style.current.darkGrey
+              color: Style.current.grey
               anchors.top: parent.top
               font.pixelSize: 15
           }
@@ -159,7 +159,7 @@ Item {
               id: timeIndicator
               text: "At "
               anchors.right: timeValue.left
-              color: Style.current.darkGrey
+              color: Style.current.grey
               anchors.top: parent.top
               font.pixelSize: 15
               font.strikeout: false

--- a/ui/app/AppLayouts/Wallet/LeftTab.qml
+++ b/ui/app/AppLayouts/Wallet/LeftTab.qml
@@ -54,7 +54,7 @@ Item {
 
         StyledText {
             id: totalValue
-            color: Style.current.darkGrey
+            color: Style.current.grey
             text: qsTr("Total value")
             anchors.left: walletAmountValue.left
             anchors.top: walletAmountValue.bottom
@@ -123,7 +123,7 @@ Item {
                 anchors.leftMargin: 0
                 font.pixelSize: 15
                 font.weight: Font.Medium
-                color: selected ? Style.current.white : Style.current.darkGrey
+                color: selected ? Style.current.white : Style.current.grey
                 opacity: selected ? 0.7 : 1
             }
             StyledText {

--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -17,17 +17,6 @@ ModalPopup {
         sendModalContent.amountInput.text = ""
         sendModalContent.passwordInput.text = ""
         sendModalContent.amountInput.forceActiveFocus(Qt.MouseFocusReason)
-        const accounts = walletModel.accounts
-        const numAccounts = accounts.rowCount()
-        const accountsData = []
-        for (let i = 0; i < numAccounts; i++) {
-            accountsData.push({
-                name: accounts.rowData(i, 'name'),
-                address: accounts.rowData(i, 'address'),
-                iconColor: accounts.rowData(i, 'iconColor')
-            })
-        }
-        sendModalContent.accounts = accountsData
 
         const assets = walletModel.assets
         const numAssets = assets.rowCount()

--- a/ui/app/AppLayouts/Wallet/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/WalletHeader.qml
@@ -64,7 +64,7 @@ Item {
         anchors.left: title.left
         anchors.leftMargin: 0
         font.pixelSize: 13
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 
     SendModal{

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.3
 import "../../../../imports"
 import "../../../../shared"
@@ -93,16 +94,43 @@ ModalPopup {
         bgColor: selectedColor
         //% "Account color"
         label: qsTrId("account-color")
-        selectOptions: Constants.accountColors.map(color => {
-            return {
-                text: "",
-                bgColor: color,
-                height: 52,
-                onClicked: function () {
-                    selectedColor = color
+        model: Constants.accountColors
+        menu.delegate: Component {
+            MenuItem {
+                property bool isFirstItem: index === 0
+                property bool isLastItem: index === Constants.accountColors.length - 1
+                height: 52
+                width: parent.width
+                padding: 10
+                onTriggered: function () {
+                    selectedColor = Constants.accountColors[index]
                 }
-           }
-        })
+                background: Rectangle {
+                    color: Constants.accountColors[index]
+                    radius: Style.current.radius
+
+                    // cover bottom left/right corners with square corners
+                    Rectangle {
+                        visible: !isLastItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.radius
+                        color: parent.color
+                    }
+
+                    // cover top left/right corners with square corners
+                    Rectangle {
+                        visible: !isFirstItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: parent.radius
+                        color: parent.color
+                    }
+                }
+            }
+        }
     }
 
     footer: StyledButton {

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithSeed.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.3
 import "../../../../imports"
 import "../../../../shared"
@@ -94,16 +95,43 @@ ModalPopup {
         bgColor: selectedColor
         //% "Account color"
         label: qsTrId("account-color")
-        selectOptions: Constants.accountColors.map(color => {
-            return {
-                text: "",
-                bgColor: color,
-                height: 52,
-                onClicked: function () {
-                    selectedColor = color
+        model: Constants.accountColors
+        menu.delegate: Component {
+            MenuItem {
+                property bool isFirstItem: index === 0
+                property bool isLastItem: index === Constants.accountColors.length - 1
+                height: 52
+                width: parent.width
+                padding: 10
+                onTriggered: function () {
+                    selectedColor = Constants.accountColors[index]
                 }
-           }
-        })
+                background: Rectangle {
+                    color: Constants.accountColors[index]
+                    radius: Style.current.radius
+
+                    // cover bottom left/right corners with square corners
+                    Rectangle {
+                        visible: !isLastItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.radius
+                        color: parent.color
+                    }
+
+                    // cover top left/right corners with square corners
+                    Rectangle {
+                        visible: !isFirstItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: parent.radius
+                        color: parent.color
+                    }
+                }
+            }
+        }
     }
 
     footer: StyledButton {

--- a/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddWatchOnlyAccount.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.3
 import "../../../../imports"
 import "../../../../shared"
@@ -68,16 +69,43 @@ ModalPopup {
         bgColor: selectedColor
         //% "Account color"
         label: qsTrId("account-color")
-        selectOptions: Constants.accountColors.map(color => {
-            return {
-                text: "",
-                bgColor: color,
-                height: 52,
-                onClicked: function () {
-                    selectedColor = color
+        model: Constants.accountColors
+        menu.delegate: Component {
+            MenuItem {
+                property bool isFirstItem: index === 0
+                property bool isLastItem: index === Constants.accountColors.length - 1
+                height: 52
+                width: parent.width
+                padding: 10
+                onTriggered: function () {
+                    selectedColor = Constants.accountColors[index]
                 }
-           }
-        })
+                background: Rectangle {
+                    color: Constants.accountColors[index]
+                    radius: Style.current.radius
+
+                    // cover bottom left/right corners with square corners
+                    Rectangle {
+                        visible: !isLastItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.radius
+                        color: parent.color
+                    }
+
+                    // cover top left/right corners with square corners
+                    Rectangle {
+                        visible: !isFirstItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: parent.radius
+                        color: parent.color
+                    }
+                }
+            }
+        }
     }
 
     footer: StyledButton {

--- a/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/GenerateAccountModal.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.3
 import "../../../../imports"
 import "../../../../shared"
@@ -68,16 +69,43 @@ ModalPopup {
         bgColor: selectedColor
         //% "Account color"
         label: qsTrId("account-color")
-        selectOptions: Constants.accountColors.map(color => {
-            return {
-                text: "",
-                bgColor: color,
-                height: 52,
-                onClicked: function () {
-                    selectedColor = color
+        model: Constants.accountColors
+        menu.delegate: Component {
+            MenuItem {
+                property bool isFirstItem: index === 0
+                property bool isLastItem: index === Constants.accountColors.length - 1
+                height: 52
+                width: parent.width
+                padding: 10
+                onTriggered: function () {
+                    selectedColor = Constants.accountColors[index]
                 }
-           }
-        })
+                background: Rectangle {
+                    color: Constants.accountColors[index]
+                    radius: Style.current.radius
+
+                    // cover bottom left/right corners with square corners
+                    Rectangle {
+                        visible: !isLastItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: parent.radius
+                        color: parent.color
+                    }
+
+                    // cover top left/right corners with square corners
+                    Rectangle {
+                        visible: !isFirstItem
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: parent.radius
+                        color: parent.color
+                    }
+                }
+            }
+        }
     }
 
     footer: StyledButton {

--- a/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.3
 import "../../../../imports"
 import "../../../../shared"
@@ -8,13 +9,7 @@ Item {
     property var closePopup: function(){}
     property alias amountInput: txtAmount
     property alias passwordInput: txtPassword
-    property var accounts: []
     property var assets: []
-
-    property int selectedAccountIndex: 0
-    property string selectedAccountAddress: accounts && accounts.length ? accounts[selectedAccountIndex].address : ""
-    property string selectedAccountName: accounts && accounts.length ? accounts[selectedAccountIndex].name : ""
-    property string selectedAccountIconColor: accounts && accounts.length ? accounts[selectedAccountIndex].iconColor : ""
 
     property int selectedAssetIndex: 0
     property string selectedAssetName: assets && assets.length ? assets[selectedAssetIndex].name : ""
@@ -30,8 +25,7 @@ Item {
         if (!validate()) {
             return;
         }
-
-        let result = walletModel.onSendTransaction(selectedAccountAddress,
+        let result = walletModel.onSendTransaction(selectFromAccount.selectedAccount.address,
                                                    txtTo.text,
                                                    selectedAssetAddress,
                                                    txtAmount.text,
@@ -125,14 +119,27 @@ Item {
         anchors.top: txtAmount.bottom
         anchors.topMargin: Style.current.padding
         selectedText: selectedAssetName
-        selectOptions: sendModalContent.assets.map(function (asset, index) {
-            return {
-                text: asset.name,
-                onClicked: function () {
+        model: sendModalContent.assets
+        menu.delegate: Component {
+            MenuItem {
+
+                height: itemText.height + 4
+                width: parent ? parent.width : selectMenu.width
+                padding: 10
+
+                StyledText {
+                    id: itemText
+                    text: sendModalContent.assets[index].name
+                    anchors.left: parent.left
+                    anchors.leftMargin: 5
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                onTriggered: function () {
                     selectedAssetIndex = index
                 }
             }
-        })
+        }
     }
 
     StyledText {
@@ -147,38 +154,14 @@ Item {
         anchors.rightMargin: 0
     }
 
-    Select {
-        id: txtFrom
-        iconHeight: 12
-        iconWidth: 12
-        icon: "../../../img/walletIcon.svg"
-        iconColor: selectedAccountIconColor
-        //% "From account"
-        label: qsTrId("from-account")
+
+    AccountSelector {
+        id: selectFromAccount
+        accounts: walletModel.accounts
         anchors.top: assetTypeSelect.bottom
         anchors.topMargin: Style.current.padding
-        selectedText: selectedAccountName
-        selectOptions: sendModalContent.accounts.map(function (account, index) {
-            return {
-                text: account.name,
-                onClicked: function () {
-                    selectedAccountIndex = index
-                }
-            }
-        })
-    }
-
-    StyledText {
-        id: textSelectAccountAddress
-        text: selectedAccountAddress
-        font.family: Style.current.fontHexRegular.name
-        anchors.right: parent.right
         anchors.left: parent.left
-        anchors.leftMargin: 2
-        elide: Text.ElideMiddle
-        anchors.top: txtFrom.bottom
-        font.pixelSize: 12
-        color: Style.current.darkGrey
+        anchors.right: parent.right
     }
 
     Input {
@@ -187,7 +170,7 @@ Item {
         label: qsTrId("recipient")
         //% "Send to"
         placeholderText: qsTrId("send-to")
-        anchors.top: textSelectAccountAddress.bottom
+        anchors.top: selectFromAccount.bottom
         anchors.topMargin: Style.current.padding
         validationError: toValidationError
     }

--- a/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
@@ -147,7 +147,7 @@ Item {
         //% "Balance: %1"
         text: qsTrId("balance:-%1").arg(selectedAccountValue)
         font.pixelSize: 13
-        color: Style.current.darkGrey
+        color: Style.current.grey
         anchors.top: assetTypeSelect.top
         anchors.topMargin: 0
         anchors.right: assetTypeSelect.right

--- a/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
@@ -67,7 +67,7 @@ Item {
                     anchors.bottomMargin: 0
                     anchors.left: assetInfoImage.right
                     anchors.leftMargin: Style.current.smallPadding
-                    color: Style.current.darkGrey
+                    color: Style.current.grey
                     font.pixelSize: 15
                 }
                 CheckBox  {

--- a/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
@@ -31,7 +31,7 @@ ModalPopup {
       text: qsTrId("confirmations-helper-text")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
       anchors.top: confirmationsCount.bottom
       anchors.topMargin: Style.current.smallPadding
     }
@@ -61,7 +61,7 @@ ModalPopup {
       text: qsTrId("block")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -87,7 +87,7 @@ ModalPopup {
       text: qsTrId("hash")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -116,7 +116,7 @@ ModalPopup {
       text: qsTrId("from")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -145,7 +145,7 @@ ModalPopup {
       text: qsTrId("to")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -173,7 +173,7 @@ ModalPopup {
       text: qsTrId("gas-limit")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -199,7 +199,7 @@ ModalPopup {
       text: qsTrId("gas-price")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -225,7 +225,7 @@ ModalPopup {
       text: qsTrId("gas-used")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {
@@ -251,7 +251,7 @@ ModalPopup {
       text: qsTrId("nonce")
       font.pixelSize: 14
       font.weight: Font.Medium
-      color: Style.current.darkGrey
+      color: Style.current.grey
     }
 
     StyledText {

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -2,14 +2,14 @@ import QtQuick 2.13
 import "."
 
 Theme {
-    property color white: "#FFFFFF"
+    property color white: "#141414"
     property color white2: "#FCFCFC"
-    property color black: "#000000"
-    property color grey: "#141414"
-    property color lightBlue: "#ECEFFC"
+    property color black: "#FFFFFF"
+    property color lightGrey: "#252528"
+    property color lightBlue: "#23252F"
     property color blue: "#758EF0"
     property color transparent: "#00000000"
-    property color darkGrey: "#838C91"
+    property color grey: "#838C91"
     property color lightBlueText: "#8f9fec"
     property color darkBlue: "#3c55c9"
     property color darkBlueBtn: "#5a70dd"
@@ -17,12 +17,12 @@ Theme {
     property color lightRed: "#FFEAEE"
     property color green: "#4EBC60"
     
-    property color background: "#141414"
-    property color border: "#252528"
-    property color textColor: white
-    property color currentUserTextColor: white
-    property color secondaryBackground: "#23252F"
+    property color background: white
+    property color border: lightGrey
+    property color textColor: black
+    property color currentUserTextColor: black
+    property color secondaryBackground: lightBlue
     property color inputBackground: secondaryBackground
-    property color inputColor: darkGrey
+    property color inputColor: lightGrey
     property color modalBackground: background
 }

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -5,7 +5,7 @@ Theme {
     property color white: "#FFFFFF"
     property color white2: "#FCFCFC"
     property color black: "#000000"
-    property color grey: "#EEF2F5"
+    property color grey: "#141414"
     property color lightBlue: "#ECEFFC"
     property color blue: "#758EF0"
     property color transparent: "#00000000"

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -5,11 +5,11 @@ Theme {
     property color white: "#FFFFFF"
     property color white2: "#FCFCFC"
     property color black: "#000000"
-    property color grey: "#EEF2F5"
+    property color lightGrey: "#EEF2F5"
     property color lightBlue: "#ECEFFC"
     property color blue: "#4360DF"
     property color transparent: "#00000000"
-    property color darkGrey: "#939BA1"
+    property color grey: "#939BA1"
     property color lightBlueText: "#8f9fec"
     property color darkBlue: "#3c55c9"
     property color darkBlueBtn: "#5a70dd"
@@ -18,11 +18,11 @@ Theme {
     property color green: "#4EBC60"
 
     property color background: white
-    property color border: grey
+    property color border: lightGrey
     property color textColor: black
-    property color currentUserTextColor: white
+    property color currentUserTextColor: black
     property color secondaryBackground: lightBlue
-    property color inputBackground: grey
+    property color inputBackground: lightGrey
     property color inputColor: black
     property color modalBackground: white2
 }

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -309,6 +309,7 @@ DISTFILES += \
     onboarding/img/wallet@2x.jpg \
     onboarding/img/wallet@3x.jpg \
     onboarding/qmldir \
+    shared/AccountSelector.qml \
     shared/AddButton.qml \
     shared/IconButton.qml \
     shared/Input.qml \

--- a/ui/onboarding/CreatePasswordModal.qml
+++ b/ui/onboarding/CreatePasswordModal.qml
@@ -83,7 +83,7 @@ ModalPopup {
         horizontalAlignment: Text.AlignHCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-        color: Style.current.darkGrey
+        color: Style.current.grey
         font.pixelSize: 12
     }
 

--- a/ui/onboarding/EnterSeedPhraseModal.qml
+++ b/ui/onboarding/EnterSeedPhraseModal.qml
@@ -39,7 +39,7 @@ ModalPopup {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-        color: Style.current.darkGrey
+        color: Style.current.grey
         font.pixelSize: 12
     }
 

--- a/ui/onboarding/KeysMain.qml
+++ b/ui/onboarding/KeysMain.qml
@@ -46,7 +46,7 @@ Page {
 
         StyledText {
             id: txtDesc1
-            color: Style.current.darkGrey
+            color: Style.current.grey
             //% "A set of keys controls your account. Your keys live on your device, so only you can use them."
             text: qsTrId("a-set-of-keys-controls-your-account.-your-keys-live-on-your-device,-so-only-you-can-use-them.")
             horizontalAlignment: Text.AlignHCenter

--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -77,7 +77,7 @@ Item {
             anchors.leftMargin: 4
             anchors.verticalCenter: usernameText.verticalCenter
 
-            color: isHovered ? Style.current.grey : Style.current.transparent
+            color: isHovered ? Style.current.lightGrey : Style.current.transparent
 
             radius: 4
 
@@ -93,7 +93,7 @@ Item {
             ColorOverlay {
                 anchors.fill: caretImg
                 source: caretImg
-                color: Style.current.darkGrey
+                color: Style.current.grey
             }
             MouseArea {
                 hoverEnabled: true
@@ -118,7 +118,7 @@ Item {
         StyledText {
             id: addressText
             width: 90
-            color: Style.current.darkGrey
+            color: Style.current.grey
             text: loginModel.currentAccount.address
             font.family: Style.current.fontHexRegular.name
             elide: Text.ElideMiddle

--- a/ui/onboarding/Login/AddressView.qml
+++ b/ui/onboarding/Login/AddressView.qml
@@ -19,7 +19,7 @@ Rectangle {
     anchors.right: parent.right
     anchors.left: parent.left
     border.width: 0
-    color: selected || isHovered ? Style.current.grey : Style.current.transparent
+    color: selected || isHovered ? Style.current.lightGrey : Style.current.transparent
     radius: Style.current.radius
 
     Identicon {
@@ -52,7 +52,7 @@ Rectangle {
         anchors.left: usernameText.left
         anchors.leftMargin: 0
         font.pixelSize: 15
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 
     MouseArea {

--- a/ui/onboarding/Slide.qml
+++ b/ui/onboarding/Slide.qml
@@ -53,7 +53,7 @@ Item {
         visible: !isFirst
         background: Rectangle {
             id: rctPrevious1
-            color: Style.current.grey
+            color: Style.current.lightGrey
             border.width: 0
             radius: 50
 
@@ -71,7 +71,7 @@ Item {
     StyledText {
         id: txtDesc1
         x: 772
-        color: Style.current.darkGrey
+        color: Style.current.grey
         text: description
         font.weight: Font.Normal
         style: Text.Normal
@@ -97,7 +97,7 @@ Item {
         visible: !isLast
         background: Rectangle {
             id: rctNext1
-            color: Style.current.grey
+            color: Style.current.lightGrey
             border.width: 0
             radius: 50
 

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -26,7 +26,7 @@ Item {
             anchors.bottomMargin: -18 
             anchors.right: parent.right
             text: "Balance: " + (parseFloat(value) === 0.0 ? "0" : value) + " " + symbol
-            color: parseFloat(value) === 0.0 ? Style.current.red : Style.current.darkGrey
+            color: parseFloat(value) === 0.0 ? Style.current.red : Style.current.grey
             font.pixelSize: 13
             height: 18
         }
@@ -62,19 +62,19 @@ Item {
             elide: Text.ElideMiddle
             height: 16
             width: 80
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
         StyledText {
             text: " • "
             font.pixelSize: 12
             height: 16
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
         StyledText {
             text: selectedAccount.fiatBalance + " " + walletModel.defaultCurrency.toUpperCase()
             font.pixelSize: 12
             height: 16
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
     }
 
@@ -127,7 +127,7 @@ Item {
                     text: address
                     elide: Text.ElideMiddle
                     width: 80
-                    color: Style.current.darkGrey
+                    color: Style.current.grey
                     font.pixelSize: 12
                     height: 16
                 }
@@ -147,7 +147,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: 15
                 height: 22
-                color: Style.current.darkGrey
+                color: Style.current.grey
                 text: walletModel.defaultCurrency.toUpperCase()
             }
             background: Rectangle {

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -1,0 +1,201 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.13
+import "../imports"
+
+Item {
+    id: root
+    property string label: qsTr("Choose account")
+    property var accounts
+    property var selectedAccount: {
+        "address": "", "name": "", "iconColor": "", "fiatBalance": ""
+    }
+    height: select.height + selectedAccountDetails.height
+    // set to asset symbol to display asset's balance top right
+    // NOTE: if this asset is not selected as a wallet token in the UI, then
+    // nothing will be displayed
+    property string showAssetBalance: ""
+
+    Repeater {
+        visible: showAssetBalance !== ""
+        model: selectedAccount.assets
+        delegate: StyledText {
+            visible: symbol === root.showAssetBalance.toUpperCase()
+            anchors.bottom: select.top
+            anchors.bottomMargin: -18 
+            anchors.right: parent.right
+            text: "Balance: " + (parseFloat(value) === 0.0 ? "0" : value) + " " + symbol
+            color: parseFloat(value) === 0.0 ? Style.current.red : Style.current.darkGrey
+            font.pixelSize: 13
+            height: 18
+        }
+    }
+    Select {
+        id: select
+        icon: "../app/img/walletIcon.svg"
+        iconColor: selectedAccount.iconColor || Style.current.blue
+        label: root.label
+        selectedText: selectedAccount.name
+        model: root.accounts
+
+        menu.delegate: menuItem
+        menu.onOpened: {
+            selectedAccountDetails.visible = false
+        }
+        menu.onClosed: {
+            selectedAccountDetails.visible = true
+        }
+    }
+
+    Row {
+        id: selectedAccountDetails
+        anchors.top: select.bottom
+        anchors.topMargin: 8
+        anchors.left: parent.left
+        anchors.leftMargin: 2
+
+        StyledText {
+            id: textSelectedAddress
+            text: selectedAccount.address
+            font.pixelSize: 12
+            elide: Text.ElideMiddle
+            height: 16
+            width: 80
+            color: Style.current.darkGrey
+        }
+        StyledText {
+            text: " • "
+            font.pixelSize: 12
+            height: 16
+            color: Style.current.darkGrey
+        }
+        StyledText {
+            text: selectedAccount.fiatBalance + " " + walletModel.defaultCurrency.toUpperCase()
+            font.pixelSize: 12
+            height: 16
+            color: Style.current.darkGrey
+        }
+    }
+
+    Component {
+        id: menuItem
+        MenuItem {
+            id: itemContainer
+            property color bgColor: Style.current.white
+            property bool isFirstItem: index === 0
+            property bool isLastItem: index === accounts.rowCount() - 1
+
+            Component.onCompleted: {
+                if (root.selectedAccount.address === "") {
+                    root.selectedAccount = { address, name, iconColor, assets, fiatBalance }
+                }
+            }
+
+            height: accountName.height + 14 + accountAddress.height + 14
+            SVGImage {
+                id: iconImg
+                anchors.left: parent.left
+                anchors.leftMargin: Style.current.padding
+                anchors.verticalCenter: parent.verticalCenter
+                width: select.iconWidth
+                height: select.iconHeight
+                sourceSize.height: select.iconHeight
+                sourceSize.width: select.iconWidth
+                fillMode: Image.PreserveAspectFit
+                source: select.icon
+            }
+            ColorOverlay {
+                anchors.fill: iconImg
+                source: iconImg
+                color: iconColor
+            }
+            Column {
+                anchors.left: iconImg.right
+                anchors.leftMargin: 14
+                anchors.verticalCenter: parent.verticalCenter
+
+                StyledText {
+                    id: accountName
+                    text: name
+                    font.pixelSize: 15
+                    height: 22
+                }
+
+                StyledText {
+                    id: accountAddress
+                    text: address
+                    elide: Text.ElideMiddle
+                    width: 80
+                    color: Style.current.darkGrey
+                    font.pixelSize: 12
+                    height: 16
+                }
+            }
+            StyledText {
+                anchors.right: fiatCurrencySymbol.left
+                anchors.rightMargin: 4
+                anchors.verticalCenter: parent.verticalCenter
+                font.pixelSize: 15
+                height: 22
+                text: fiatBalance
+            }
+            StyledText {
+                id: fiatCurrencySymbol
+                anchors.right: parent.right
+                anchors.rightMargin: Style.current.padding
+                anchors.verticalCenter: parent.verticalCenter
+                font.pixelSize: 15
+                height: 22
+                color: Style.current.darkGrey
+                text: walletModel.defaultCurrency.toUpperCase()
+            }
+            background: Rectangle {
+                color: itemContainer.bgColor
+                radius: Style.current.radius
+
+                // cover bottom left/right corners with square corners
+                Rectangle {
+                    visible: !isLastItem
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: parent.radius
+                    color: parent.color
+                }
+
+                // cover top left/right corners with square corners
+                Rectangle {
+                    visible: !isFirstItem
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    height: parent.radius
+                    color: parent.color
+                }
+            }
+            MouseArea {
+                cursorShape: Qt.PointingHandCursor
+                anchors.fill: itemContainer
+                hoverEnabled: true
+                onEntered: {
+                    itemContainer.bgColor = Style.current.lightGrey
+                }
+                onExited: {
+                    itemContainer.bgColor = Style.current.white
+                }
+                onClicked: {
+                    root.selectedAccount = { address, name, iconColor, assets, fiatBalance }
+                    select.menu.close()
+                }
+            }
+        }
+    }
+}
+
+
+/*##^##
+Designer {
+    D{i:0;autoSize:true;height:480;width:640}
+}
+##^##*/

--- a/ui/shared/CopyToClipBoardButton.qml
+++ b/ui/shared/CopyToClipBoardButton.qml
@@ -27,10 +27,10 @@ Rectangle {
             parent.color = Style.current.transparent
         }
         onEntered:{
-            parent.color = Style.current.grey
+            parent.color = Style.current.lightGrey
         }
         onPressed: {
-            parent.color = Style.current.darkGrey
+            parent.color = Style.current.grey
         }
         onReleased: {
             parent.color = Style.current.transparent

--- a/ui/shared/Select.qml
+++ b/ui/shared/Select.qml
@@ -88,7 +88,7 @@ Item {
         ColorOverlay {
             anchors.fill: caret
             source: caret
-            color: Style.current.darkGrey
+            color: Style.current.grey
         }
     }
 

--- a/ui/shared/Select.qml
+++ b/ui/shared/Select.qml
@@ -9,34 +9,32 @@ Item {
     readonly property bool hasLabel: label !== ""
     property color bgColor: Style.current.inputBackground
     readonly property int labelMargin: 7
-    property var selectOptions
-    property int customHeight: 44
+    property var model
+    property int customHeight: 56
     property string selectedText: ""
     property url icon: ""
-    property int iconHeight: 24
-    property int iconWidth: 24
+    property int iconHeight: 12
+    property int iconWidth: 12
     property color iconColor: Style.current.transparent
+    property alias menu: selectMenu
 
     readonly property bool hasIcon: icon.toString() !== ""
 
-    id: inputBox
+    id: root
     height: inputRectangle.height + (hasLabel ? inputLabel.height + labelMargin : 0)
     anchors.right: parent.right
     anchors.left: parent.left
 
-    onSelectOptionsChanged: {
-        selectMenu.setupMenuItems()
-    }
-
     StyledText {
         id: inputLabel
-        text: inputBox.label
+        text: root.label
         font.weight: Font.Medium
         anchors.left: parent.left
         anchors.leftMargin: 0
         anchors.top: parent.top
         anchors.topMargin: 0
         font.pixelSize: 13
+        height: 18
     }
 
     Rectangle {
@@ -44,20 +42,21 @@ Item {
         height: customHeight
         color: bgColor
         radius: Style.current.radius
-        anchors.top: inputBox.hasLabel ? inputLabel.bottom : parent.top
-        anchors.topMargin: inputBox.hasLabel ? inputBox.labelMargin : 0
+        anchors.top: root.hasLabel ? inputLabel.bottom : parent.top
+        anchors.topMargin: root.hasLabel ? root.labelMargin : 0
         anchors.right: parent.right
         anchors.left: parent.left
 
         SVGImage {
             id: iconImg
+            visible: root.hasIcon
             sourceSize.height: iconHeight
             sourceSize.width: iconWidth
             anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
+            anchors.leftMargin: Style.current.padding
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
-            source: inputBox.icon
+            source: root.icon
         }
         ColorOverlay {
             anchors.fill: iconImg
@@ -67,12 +66,13 @@ Item {
 
         StyledText {
             id: selectedTextField
-            visible: inputBox.selectedText !== ""
-            text: inputBox.selectedText
-            anchors.left: parent.left
-            anchors.leftMargin: inputBox.hasIcon ? iconWidth + 20 : Style.current.padding
+            visible: root.selectedText !== ""
+            text: root.selectedText
+            anchors.left: iconImg.right
+            anchors.leftMargin: hasIcon ? 8 : 0
             anchors.verticalCenter: parent.verticalCenter
             font.pixelSize: 15
+            height: 22
         }
 
         SVGImage {
@@ -90,78 +90,59 @@ Item {
             source: caret
             color: Style.current.darkGrey
         }
+    }
 
-        Menu {
-            property var items: []
-
-            id: selectMenu
-            width: parent.width
-            padding: 10
-            background: Rectangle {
-                width: parent.width
-                height: parent.height
-                color: Style.current.inputBackground
-                radius: Style.current.radius
-            }
-
-            function setupMenuItems() {
-                if (selectMenu.items.length) {
-                    // Remove old items
-                    selectMenu.items.forEach(function (item) {
-                        selectMenu.removeItem(item)
-                    })
-                    selectMenu.items = []
-                }
-                if (!selectOptions) {
-                    return
-                }
-
-                selectOptions.forEach(function (element) {
-                    var item = menuItem.createObject(undefined, element)
-                    selectMenu.items.push(item)
-                    selectMenu.addItem(item)
-                })
-            }
-
-            Component.onCompleted: {
-                setupMenuItems()
-            }
-
-            Component {
-                id: menuItem
-                MenuItem {
-                    id: itemContainer
-                    property var onClicked: function () {}
-                    property string label: ""
-                    property color bgColor: Style.current.transparent
-
-                    height: itemText.height + 4
-                    width: parent ? parent.width : selectMenu.width
-
-                    StyledText {
-                        id: itemText
-                        text: itemContainer.label
-                        anchors.left: parent ? parent.left : undefined
-                        anchors.leftMargin: 5
-                        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
-                    }
-
-                    onTriggered: function () {
-                        onClicked()
-                    }
-                    background: Rectangle {
-                        color: bgColor
-                    }
-                }
-            }
+    // create a drop shadow externally so that it is not clipped by the 
+    // rounded corners of the menu background
+    Rectangle {
+        width: selectMenu.width
+        height: selectMenu.height
+        x: selectMenu.x
+        y: selectMenu.y
+        visible: selectMenu.opened
+        color: Style.current.white
+        radius: Style.current.radius
+        border.color: Style.current.border
+        layer.enabled: true
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: Style.current.radius
+            samples: 15
+            fast: true
+            cached: true
+            color: "#22000000"
         }
     }
 
+    Menu {
+        id: selectMenu
+        property var items: []
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+        width: parent.width
+        background: Rectangle {
+            // do not add a drop shadow effect here or it will be clipped
+            radius: Style.current.radius
+            color: Style.current.white
+        }
+        clip: true
+        delegate: menuItem
+
+        Repeater {
+            id: menuItems
+            model: root.model
+            delegate: selectMenu.delegate
+        }
+    }
     MouseArea {
         id: mouseArea
-        anchors.fill: parent
+        anchors.fill: inputRectangle
+        cursorShape: Qt.PointingHandCursor
         onClicked: {
-            selectMenu.open()
+            if (selectMenu.opened) {
+                selectMenu.close()
+            } else {
+                selectMenu.popup(inputRectangle.x, inputRectangle.y + inputRectangle.height + 8)
+            }
         }
     }
 }

--- a/ui/shared/SplitViewHandle.qml
+++ b/ui/shared/SplitViewHandle.qml
@@ -4,6 +4,6 @@ import "../imports"
 
 Rectangle {
     implicitWidth: 1.2
-    color: SplitHandle.pressed ? Style.current.darkGrey
+    color: SplitHandle.pressed ? Style.current.grey
                 : (SplitHandle.hovered ? Qt.darker(Style.current.border, 1.1) : Style.current.border)
 }

--- a/ui/shared/StatusTabButton.qml
+++ b/ui/shared/StatusTabButton.qml
@@ -20,7 +20,7 @@ TabButton {
         text: btnText
         font.weight: Font.Medium
         font.pixelSize: 15
-        color: parent.checked ? Style.current.textColor : Style.current.darkGrey
+        color: parent.checked ? Style.current.textColor : Style.current.grey
     }
 
     Rectangle {

--- a/ui/shared/StyledButton.qml
+++ b/ui/shared/StyledButton.qml
@@ -17,7 +17,7 @@ Button {
     enabled: !disabled
 
     background: Rectangle {
-        color: disabled ? Style.current.grey : btnStyled.btnColor
+        color: disabled ? Style.current.lightGrey : btnStyled.btnColor
         radius: Style.current.radius
         anchors.fill: parent
         border.color: btnBorderColor
@@ -26,7 +26,7 @@ Button {
 
     StyledText {
         id: txtBtnLabel
-        color: btnStyled.disabled ? Style.current.darkGrey : btnStyled.textColor
+        color: btnStyled.disabled ? Style.current.grey : btnStyled.textColor
         font.pixelSize: 15
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/shared/TextWithLabel.qml
+++ b/ui/shared/TextWithLabel.qml
@@ -18,7 +18,7 @@ Item {
         text: infoText.label
         font.weight: Font.Medium
         font.pixelSize: 13
-        color: Style.current.darkGrey
+        color: Style.current.grey
     }
 
     StyledTextEdit {


### PR DESCRIPTION
Removes `darkGrey` and replaces it with `grey`. So now we have `grey` and `lightGrey` only. This is meant to simplify following dark mode color changes, as shown in the design:
![Imgur](https://imgur.com/gljG2Gn.png)

As a side note, for future reference, when we are creating QML components, simply specify the light mode color (ie `Style.current.white`) and when the user switches to dark mode, `white` switches from `#FFFFFF` to `#141414` (almost black) automatically, which follows the design for dark mode.