### PR TITLE
fix: alignment of emojis

### DIFF
--- a/src/app/chat/views/message_format.nim
+++ b/src/app/chat/views/message_format.nim
@@ -29,7 +29,7 @@ proc renderBlock(self: ChatMessageList, message: Message): string =
   for pMsg in message.parsedText:
     case pMsg.textType:
       of "paragraph": 
-        result = result & "<p>"
+        result = result & "<p>&nbsp;"
         for children in pMsg.children:
           result = result & self.renderInline(children)
         result = result & "</p>"

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -93,6 +93,7 @@ Rectangle {
                 default: return lastMessage ? Emoji.parse(lastMessage, "26x26").replace(/\n|\r/g, ' ') : qsTrId("no-messages")
             }
         }
+        textFormat: Text.RichText
         clip: true // This is needed because emojis don't ellide correctly
         anchors.right: contactNumberChatsCircle.left
         anchors.rightMargin: Style.current.smallPadding


### PR DESCRIPTION
- Added a &nsbp; in front of paragraphs, otherwise the alignment property was ignored
- Enabled richformat for channel list to avoid emoji overlap in last message