### PR TITLE
fix: Remove walletModel reference from AccountSelector

### DIFF
--- a/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SendModalContent.qml
@@ -114,6 +114,7 @@ Item {
     AccountSelector {
         id: selectFromAccount
         accounts: walletModel.accounts
+        currency: walletModel.defaultCurrency
         anchors.top: selectAsset.bottom
         anchors.topMargin: Style.current.padding
         anchors.left: parent.left

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -11,6 +11,7 @@ Item {
     property var selectedAccount: {
         "address": "", "name": "", "iconColor": "", "fiatBalance": ""
     }
+    property string currency: "usd"
     height: select.height + selectedAccountDetails.height
     // set to asset symbol to display asset's balance top right
     // NOTE: if this asset is not selected as a wallet token in the UI, then
@@ -99,7 +100,7 @@ Item {
             color: Style.current.secondaryText
         }
         StyledText {
-            text: selectedAccount.fiatBalance + " " + walletModel.defaultCurrency.toUpperCase()
+            text: selectedAccount.fiatBalance + " " + root.currency.toUpperCase()
             font.pixelSize: 12
             height: 16
             color: Style.current.secondaryText
@@ -175,7 +176,7 @@ Item {
                 font.pixelSize: 15
                 height: 22
                 color: Style.current.secondaryText
-                text: walletModel.defaultCurrency.toUpperCase()
+                text: root.currency.toUpperCase()
             }
             background: Rectangle {
                 color: itemContainer.highlighted ? Style.current.backgroundHover : Style.current.background


### PR DESCRIPTION
Remove all `walletModel` references from the `AccountSelector` component, as the component should not be aware of the API's existence.

Pass currency to `AccountSelector` component.