### PR TITLE
build: dynamically link to status-go built as a shared library

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -12,9 +12,11 @@ if defined(macosx):
   --dynlibOverrideAll # don't use dlopen()
   --tlsEmulation:off
   switch("passL", "-lstdc++")
-  # DYLD_LIBRARY_PATH doesn't seem to work with Qt5
+  # DYLD_LIBRARY_PATH doesn't always work when running/packaging so set rpath
+  # note: macdeployqt rewrites rpath appropriately when building the .app bundle
   switch("passL", "-rpath" & " " & getEnv("QT5_LIBDIR"))
-  # statically linke these libs
+  switch("passL", "-rpath" & " " & getEnv("STATUSGO_LIBDIR"))
+  # statically link these libs
   switch("passL", "bottles/openssl/lib/libcrypto.a")
   switch("passL", "bottles/openssl/lib/libssl.a")
   switch("passL", "bottles/pcre/lib/libpcre.a")


### PR DESCRIPTION
~~This shouldn't be merged yet because `vendor/status-go` in this branch currently points to a commit in open PR https://github.com/status-im/status-go/pull/2015.~~

~~Also, earlier today when testing this repo's `master` with `vendor/status-go` pointing to current HEAD of status-go I found that the application completely locks up when you try to join a chat. Note that problem is not connected to changes in this PR but builds with this branch have the same issue because https://github.com/status-im/status-go/pull/2015 is one commit ahead of current HEAD of status-go.~~

Good to go now!