### PR TITLE
feat: get and display emoji reactions in chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 	cp ui/i18n/* tmp/linux/dist/usr/i18n
 
 	echo -e $(BUILD_MSG) "AppImage"
-	linuxdeployqt tmp/linux/dist/nim-status.desktop -no-translations -no-copy-copyright-files -qmldir=ui -qmlimport=$(QTDIR)/qml -bundle-non-qt-libs
+	linuxdeployqt tmp/linux/dist/nim-status.desktop -no-copy-copyright-files -qmldir=ui -qmlimport=$(QTDIR)/qml -bundle-non-qt-libs
 
 	rm tmp/linux/dist/AppRun
 	cp AppRun tmp/linux/dist/.

--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -5,6 +5,7 @@ import ../../status/messages as messages_model
 import ../../signals/types
 import ../../status/libstatus/types as status_types
 import ../../status/libstatus/wallet as status_wallet
+import ../../status/libstatus/settings as status_settings
 import ../../status/[chat, contacts, status]
 import view, views/channels_list, views/message_list
 
@@ -34,8 +35,9 @@ proc init*(self: ChatController) =
   self.handleChatEvents()
   self.status.mailservers.init()
   self.status.chat.init()
-  
   self.view.obtainAvailableStickerPacks()
+  let pubKey = status_settings.getSetting[string](Setting.PublicKey, "0x0")
+  self.view.pubKey = pubKey
 
   let recentStickers = self.status.chat.getRecentStickers()
   for sticker in recentStickers:

--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -3,6 +3,9 @@ proc handleChatEvents(self: ChatController) =
   # Display already saved messages
   self.status.events.on("messagesLoaded") do(e:Args):
     self.view.pushMessages(MsgsLoadedArgs(e).messages)
+  # Display emoji reactions
+  self.status.events.on("reactionsLoaded") do(e:Args):
+    self.view.pushReactions(ReactionsLoadedArgs(e).reactions)
 
   self.status.events.on("contactUpdate") do(e: Args):
     var evArgs = ContactUpdateArgs(e)
@@ -13,6 +16,7 @@ proc handleChatEvents(self: ChatController) =
     self.view.updateUsernames(evArgs.contacts)
     self.view.updateChats(evArgs.chats)
     self.view.pushMessages(evArgs.messages)
+    self.view.pushReactions(evArgs.emojiReactions)
 
   self.status.events.on("channelUpdate") do(e: Args):
     var evArgs = ChatUpdateArgs(e)
@@ -26,6 +30,7 @@ proc handleChatEvents(self: ChatController) =
     var channel = ChannelArgs(e)
     discard self.view.chats.addChatItemToList(channel.chat)
     self.status.chat.chatMessages(channel.chat.id)
+    self.status.chat.chatReactions(channel.chat.id)
 
   self.status.events.on("chatsLoaded") do(e:Args):
     self.view.calculateUnreadMessages()
@@ -36,6 +41,7 @@ proc handleChatEvents(self: ChatController) =
     var channel = ChannelArgs(e)
     discard self.view.chats.addChatItemToList(channel.chat)
     self.status.chat.chatMessages(channel.chat.id)
+    self.status.chat.chatReactions(channel.chat.id)
     self.view.setActiveChannel(channel.chat.id)
 
   self.status.events.on("channelLeft") do(e: Args):

--- a/src/app/chat/signal_handling.nim
+++ b/src/app/chat/signal_handling.nim
@@ -1,6 +1,6 @@
 
 proc handleMessage(self: ChatController, data: MessageSignal) =
-  self.status.chat.update(data.chats, data.messages)
+  self.status.chat.update(data.chats, data.messages, data.emojiReactions)
 
 proc handleDiscoverySummary(self: ChatController, data: DiscoverySummarySignal) =
   ## Handle mailserver peers being added and removed

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -253,6 +253,9 @@ QtObject:
         else:
           self.newMessagePushed()
 
+  proc addEmojiReaction*(self: ChatsView, messageId: string, emojiId: int) {.slot.} =
+    self.status.chat.addEmojiReaction(self.activeChannel.id, messageId, emojiId)
+
   proc pushReactions*(self:ChatsView, reactions: var seq[Reaction]) =
     let t = reactions.len
     for reaction in reactions.mitems:

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -31,6 +31,7 @@ QtObject:
       stickerPacks*: StickerPackList
       recentStickers*: StickerList
       replyTo: string
+      pubKey*: string
       channelOpenTime*: Table[string, int64]
       connected: bool
       unreadMessageCnt: int
@@ -58,6 +59,7 @@ QtObject:
     result.stickerPacks = newStickerPackList()
     result.recentStickers = newStickerList()
     result.unreadMessageCnt = 0
+    result.pubKey = ""
     result.setup()
 
   proc addStickerPackToList*(self: ChatsView, stickerPack: StickerPack, isInstalled, isBought: bool) =
@@ -253,8 +255,24 @@ QtObject:
         else:
           self.newMessagePushed()
 
-  proc addEmojiReaction*(self: ChatsView, messageId: string, emojiId: int) {.slot.} =
-    self.status.chat.addEmojiReaction(self.activeChannel.id, messageId, emojiId)
+  proc messageEmojiReactionId(self: ChatsView, chatId: string, messageId: string, emojiId: int): string =
+    let message = self.messageList[chatId].getMessageById(messageId)
+    if (message.emojiReactions == "") :
+      return ""
+
+    let oldReactions = parseJson(message.emojiReactions)
+
+    for pair in oldReactions.pairs:
+      if (pair[1]["emojiId"].getInt == emojiId and pair[1]["from"].getStr == self.pubKey):
+        return pair[0]
+    return ""
+
+  proc toggleEmojiReaction*(self: ChatsView, messageId: string, emojiId: int) {.slot.} =
+    let emojiReactionId = self.messageEmojiReactionId(self.activeChannel.id, messageId, emojiId)
+    if (emojiReactionId == ""):
+      self.status.chat.addEmojiReaction(self.activeChannel.id, messageId, emojiId)
+    else:
+      self.status.chat.removeEmojiReaction(emojiReactionId)
 
   proc pushReactions*(self:ChatsView, reactions: var seq[Reaction]) =
     let t = reactions.len

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -253,6 +253,31 @@ QtObject:
         else:
           self.newMessagePushed()
 
+  proc pushReactions*(self:ChatsView, reactions: var seq[Reaction]) =
+    let t = reactions.len
+    for reaction in reactions.mitems:
+      let messageList = self.messageList[reaction.chatId]
+      var message = messageList.getMessageById(reaction.messageId)
+      var oldReactions: JsonNode
+      if (message.emojiReactions == "") :
+        oldReactions = %*{}
+      else: 
+        oldReactions = parseJson(message.emojiReactions)
+
+      if (oldReactions.hasKey(reaction.id)):
+        if (reaction.retracted):
+          # Remove the reaction
+          oldReactions.delete(reaction.id)
+          messageList.setMessageReactions(reaction.messageId, $oldReactions)
+        continue
+
+      oldReactions[reaction.id] = %* {
+        "from": reaction.fromAccount,
+        "emojiId": reaction.emojiId
+      }
+      messageList.setMessageReactions(reaction.messageId, $oldReactions)
+
+
   proc updateUsernames*(self:ChatsView, contacts: seq[Profile]) =
     if contacts.len > 0:
       # Updating usernames for all the messages list
@@ -297,6 +322,7 @@ QtObject:
   proc loadMoreMessages*(self: ChatsView) {.slot.} =
     trace "Loading more messages", chaId = self.activeChannel.id
     self.status.chat.chatMessages(self.activeChannel.id, false)
+    self.status.chat.chatReactions(self.activeChannel.id, false)
     self.messagesLoaded();
 
   proc loadMoreMessagesWithIndex*(self: ChatsView, channelIndex: int) {.slot.} =
@@ -305,6 +331,7 @@ QtObject:
     if (selectedChannel == nil): return
     trace "Loading more messages", chaId = selectedChannel.id
     self.status.chat.chatMessages(selectedChannel.id, false)
+    self.status.chat.chatReactions(selectedChannel.id, false)
     self.messagesLoaded();
 
   proc leaveChatByIndex*(self: ChatsView, channelIndex: int) {.slot.} =

--- a/src/signals/core.nim
+++ b/src/signals/core.nim
@@ -62,6 +62,7 @@ QtObject:
     
     case signalType:
       of SignalType.Message:
+        echo $jsonSignal
         signal = messages.fromEvent(jsonSignal)
       of SignalType.EnvelopeSent:
         signal = envelopes.fromEvent(jsonSignal)

--- a/src/signals/core.nim
+++ b/src/signals/core.nim
@@ -62,7 +62,6 @@ QtObject:
     
     case signalType:
       of SignalType.Message:
-        echo $jsonSignal
         signal = messages.fromEvent(jsonSignal)
       of SignalType.EnvelopeSent:
         signal = envelopes.fromEvent(jsonSignal)

--- a/src/signals/messages.nim
+++ b/src/signals/messages.nim
@@ -11,6 +11,8 @@ proc toMessage*(jsonMsg: JsonNode): Message
 
 proc toChat*(jsonChat: JsonNode): Chat
 
+proc toReaction*(jsonReaction: JsonNode): Reaction
+
 proc fromEvent*(event: JsonNode): Signal = 
   var signal:MessageSignal = MessageSignal()
   signal.messages = @[]
@@ -42,6 +44,10 @@ proc fromEvent*(event: JsonNode): Signal =
   if event["event"]{"installations"} != nil:
     for jsonInstallation in event["event"]["installations"]:
       signal.installations.add(jsonInstallation.toInstallation)
+
+  if event["event"]{"emojiReactions"} != nil:
+    for jsonReaction in event["event"]["emojiReactions"]:
+      signal.emojiReactions.add(jsonReaction.toReaction)
 
   result = signal
 
@@ -195,4 +201,12 @@ proc toMessage*(jsonMsg: JsonNode): Message =
 
   result = message
 
-
+proc toReaction*(jsonReaction: JsonNode): Reaction =
+  result = Reaction(
+      id: jsonReaction{"id"}.getStr,
+      chatId: jsonReaction{"chatId"}.getStr,
+      fromAccount: jsonReaction{"from"}.getStr,
+      messageId: jsonReaction{"messageId"}.getStr,
+      emojiId: jsonReaction{"emojiId"}.getInt,
+      retracted: jsonReaction{"retracted"}.getBool
+    )

--- a/src/signals/types.nim
+++ b/src/signals/types.nim
@@ -32,6 +32,7 @@ type MessageSignal* = ref object of Signal
   chats*: seq[Chat]
   contacts*: seq[Profile]
   installations*: seq[Installation]
+  emojiReactions*: seq[Reaction]
   
 type Filter* = object
   chatId*: string

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -281,6 +281,10 @@ proc addEmojiReaction*(self: ChatModel, chatId: string, messageId: string, emoji
   let reactions = status_chat.addEmojiReaction(chatId, messageId, emojiId)
   self.events.emit("reactionsLoaded", ReactionsLoadedArgs(reactions: reactions))
 
+proc removeEmojiReaction*(self: ChatModel, emojiReactionId: string) =
+  let reactions = status_chat.removeEmojiReaction(emojiReactionId)
+  self.events.emit("reactionsLoaded", ReactionsLoadedArgs(reactions: reactions))
+
 proc markAllChannelMessagesRead*(self: ChatModel, chatId: string): JsonNode =
   var response = status_chat.markAllRead(chatId)
   result = parseJson(response)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -277,6 +277,9 @@ proc chatReactions*(self: ChatModel, chatId: string, initialLoad:bool = true) =
   except Exception as e:
     error "Error reactions", msg = e.msg
   
+proc addEmojiReaction*(self: ChatModel, chatId: string, messageId: string, emojiId: int) =
+  let reactions = status_chat.addEmojiReaction(chatId, messageId, emojiId)
+  self.events.emit("reactionsLoaded", ReactionsLoadedArgs(reactions: reactions))
 
 proc markAllChannelMessagesRead*(self: ChatModel, chatId: string): JsonNode =
   var response = status_chat.markAllRead(chatId)

--- a/src/status/chat/message.nim
+++ b/src/status/chat/message.nim
@@ -48,6 +48,15 @@ type Message* = object
   image*: string
   audio*: string
   audioDurationMs*: int
+  emojiReactions*: string
+
+type Reaction* = object
+  id*: string
+  chatId*: string
+  fromAccount*: string
+  messageId*: string
+  emojiId*: int
+  retracted*: bool
 
 
 proc `$`*(self: Message): string =

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -92,6 +92,17 @@ proc addEmojiReaction*(chatId: string, messageId: string, emojiId: int): seq[Rea
       reactions.add(jsonMsg.toReaction)
   
   result = reactions
+
+proc removeEmojiReaction*(emojiReactionId: string): seq[Reaction] =
+  let rpcResult = parseJson(callPrivateRPC("sendEmojiReactionRetraction".prefix, %* [emojiReactionId]))["result"]
+ 
+  var reactions: seq[Reaction] = @[]
+  if rpcResult != nil and rpcResult["emojiReactions"] != nil and rpcResult["emojiReactions"].len != 0:
+    for jsonMsg in rpcResult["emojiReactions"]:
+      reactions.add(jsonMsg.toReaction)
+  
+  result = reactions
+
 # TODO this probably belongs in another file
 proc generateSymKeyFromPassword*(): string =
   result = ($parseJson(callPrivateRPC("waku_generateSymKeyFromPassword", %* [

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -83,6 +83,15 @@ proc getEmojiReactionsByChatId*(chatId: string, cursor: string = ""): (string, s
 
   return (rpcResult{"cursor"}.getStr, reactions)
 
+proc addEmojiReaction*(chatId: string, messageId: string, emojiId: int): seq[Reaction] =
+  let rpcResult = parseJson(callPrivateRPC("sendEmojiReaction".prefix, %* [chatId, messageId, emojiId]))["result"]
+  
+  var reactions: seq[Reaction] = @[]
+  if rpcResult != nil and rpcResult["emojiReactions"] != nil and rpcResult["emojiReactions"].len != 0:
+    for jsonMsg in rpcResult["emojiReactions"]:
+      reactions.add(jsonMsg.toReaction)
+  
+  result = reactions
 # TODO this probably belongs in another file
 proc generateSymKeyFromPassword*(): string =
   result = ($parseJson(callPrivateRPC("waku_generateSymKeyFromPassword", %* [

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -65,6 +65,24 @@ proc chatMessages*(chatId: string, cursor: string = ""): (string, seq[Message]) 
 
   return (rpcResult{"cursor"}.getStr, messages)
 
+
+proc getEmojiReactionsByChatId*(chatId: string, cursor: string = ""): (string, seq[Reaction]) =
+  var reactions: seq[Reaction] = @[]
+  var cursorVal: JsonNode
+  
+  if cursor == "":
+    cursorVal = newJNull()
+  else:
+    cursorVal = newJString(cursor)
+
+  let rpcResult = parseJson(callPrivateRPC("emojiReactionsByChatID".prefix, %* [chatId, cursorVal, 20]))["result"]
+
+  if rpcResult != nil and rpcResult.len != 0:
+    for jsonMsg in rpcResult:
+      reactions.add(jsonMsg.toReaction)
+
+  return (rpcResult{"cursor"}.getStr, reactions)
+
 # TODO this probably belongs in another file
 proc generateSymKeyFromPassword*(): string =
   result = ($parseJson(callPrivateRPC("waku_generateSymKeyFromPassword", %* [

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -229,6 +229,7 @@ ScrollView {
             authorPrevMsg: msgDelegate.ListView.previousSection
             profileClick: profilePopup.setPopupData.bind(profilePopup)
             messageId: model.messageId
+            emojiReactions: model.emojiReactions
             prevMessageIndex: {
                 // This is used in order to have access to the previous message and determine the timestamp
                 // we can't rely on the index because the sequence of messages is not ordered on the nim side

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -18,6 +18,7 @@ Item {
     property string outgoingStatus: ""
     property string responseTo: ""
     property string messageId: ""
+    property string emojiReactions: ""
     property int prevMessageIndex: -1
     property bool timeout: false
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -45,7 +45,7 @@ StyledTextEdit {
                         `white-space: pre-wrap;`+
                     `}`+
                     `a {`+
-                        `color: ${isCurrentUser ? Style.current.white : Style.current.textColor};`+
+                        `color: ${isCurrentUser && !appSettings.compactMode ? Style.current.white : Style.current.textColor};`+
                     `}`+
                     `a.mention {`+
                         `color: ${isCurrentUser ? Style.current.cyan : Style.current.turquoise};`+

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -151,4 +151,18 @@ Item {
             audioSource: audio
         }
     }
+
+    Loader {
+        id: emojiReactionLoader
+        active: emojiReactions !== ""
+        sourceComponent: emojiReactionsComponent
+        anchors.top: chatText.bottom
+        anchors.left: chatText.left
+        anchors.topMargin: 2
+    }
+
+    Component {
+        id: emojiReactionsComponent
+        EmojiReactions {}
+    }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -94,6 +94,15 @@ Item {
                 font.pixelSize: 12
                 color: modelData.currentUserReacted ? Style.current.currentUserTextColor : Style.current.textColor
             }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    chatsModel.toggleEmojiReaction(messageId, modelData.emojiId)
+
+                }
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -28,7 +28,7 @@ Item {
                         }
                     }
                     byEmoji[reaction.emojiId].count++;
-                    if (!byEmoji[reaction.emojiId].currentUserReacted && reaction.fromAuthor === profileModel.profile.pubKey) {
+                    if (!byEmoji[reaction.emojiId].currentUserReacted && reaction.from === profileModel.profile.pubKey) {
                         byEmoji[reaction.emojiId].currentUserReacted = true
                     }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -1,0 +1,99 @@
+import QtQuick 2.3
+import "../../../../../shared"
+import "../../../../../imports"
+
+Item {
+    property int imageMargin: 4
+    id: root
+    height: 20
+    width: childrenRect.width
+
+    Repeater {
+        id: reactionepeater
+        model: {
+            if (!emojiReactions) {
+                return []
+            }
+
+            try {
+                // group by id
+                var allReactions = Object.values(JSON.parse(emojiReactions))
+                var byEmoji = {}
+                allReactions.forEach(function (reaction) {
+                    if (!byEmoji[reaction.emojiId]) {
+                        byEmoji[reaction.emojiId] = {
+                            emojiId: reaction.emojiId,
+                            count: 0,
+                            currentUserReacted: false
+                        }
+                    }
+                    byEmoji[reaction.emojiId].count++;
+                    if (!byEmoji[reaction.emojiId].currentUserReacted && reaction.fromAuthor === profileModel.profile.pubKey) {
+                        byEmoji[reaction.emojiId].currentUserReacted = true
+                    }
+
+                })
+                return Object.values(byEmoji)
+            } catch (e) {
+                console.error('Error parsing emoji reactions', e)
+                return []
+            }
+
+        }
+
+        Rectangle {
+            width: emojiImage.width + emojiCount.width + (root.imageMargin * 2) +  + 8
+            height: 20
+            radius: 10
+            anchors.left: (index === 0) ? parent.left: parent.children[index-1].right
+            anchors.leftMargin: (index === 0) ? 0 : root.imageMargin
+            color: modelData.currentUserReacted ? Style.current.blue : Style.current.grey
+
+
+            // Rounded corner to cover one corner
+            Rectangle {
+                color: parent.color
+                width: 8
+                height: 8
+                anchors.top: parent.top
+                anchors.left: !isCurrentUser ? parent.left : undefined
+                anchors.leftMargin: 0
+                anchors.right: !isCurrentUser ? undefined : parent.right
+                anchors.rightMargin: 0
+                radius: 2
+                z: -1
+            }
+
+            SVGImage {
+                id: emojiImage
+                width: 15
+                fillMode: Image.PreserveAspectFit
+                source: {
+                    const basePath = "../../../../img/emojiReactions/"
+                    switch (modelData.emojiId) {
+                    case 1: return basePath + "heart.svg"
+                    case 2: return basePath + "thumbsUp.svg"
+                    case 3: return basePath + "thumbsDown.svg"
+                    case 4: return basePath + "laughing.svg"
+                    case 5: return basePath + "sad.svg"
+                    case 6: return basePath + "angry.svg"
+                    default: return ""
+                    }
+                }
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.leftMargin: root.imageMargin
+            }
+
+            StyledText {
+                id: emojiCount
+                text: modelData.count
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: emojiImage.right
+                anchors.leftMargin: root.imageMargin
+                font.pixelSize: 12
+                color: modelData.currentUserReacted ? Style.current.currentUserTextColor : Style.current.textColor
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
@@ -42,6 +42,7 @@ Rectangle {
             verticalPadding: imageChatBox.chatVerticalPadding
             anchors.top: (index === 0) ? parent.top: parent.children[index-1].bottom
             anchors.topMargin: verticalPadding
+            anchors.horizontalCenter: parent.horizontalCenter
             source: modelData
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -199,4 +199,19 @@ Item {
         id: imageComponent
         ImageMessage {}
     }
+
+    Loader {
+        id: emojiReactionLoader
+        active: emojiReactions !== ""
+        sourceComponent: emojiReactionsComponent
+        anchors.left: !isCurrentUser ? chatBox.left : undefined
+        anchors.right: !isCurrentUser ? undefined : chatBox.right
+        anchors.top: chatBox.bottom
+        anchors.topMargin: 2
+    }
+
+    Component {
+        id: emojiReactionsComponent
+        EmojiReactions {}
+    }
 }

--- a/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
+++ b/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
@@ -13,7 +13,7 @@ SVGImage {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-            chatsModel.addEmojiReaction(SelectedMessage.messageId, emojiId)
+            chatsModel.toggleEmojiReaction(SelectedMessage.messageId, emojiId)
             reactionImage.closeModal()
 
         }

--- a/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
+++ b/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
@@ -3,7 +3,9 @@ import "../../../../imports"
 import "../../../../shared"
 
 SVGImage {
+    property var closeModal: function () {}
     property int emojiId
+    id: reactionImage
     width: 32
     fillMode: Image.PreserveAspectFit
 
@@ -11,8 +13,8 @@ SVGImage {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-            console.log('Clicked on Emoji', emojiId)
-            console.log('This feature will be implmented at a later date')
+            chatsModel.addEmojiReaction(SelectedMessage.messageId, emojiId)
+            reactionImage.closeModal()
 
         }
     }

--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -30,6 +30,9 @@ PopupMenu {
                 delegate: EmojiReaction {
                     source: "../../../img/" + filename
                     emojiId: model.emojiId
+                    closeModal: function () {
+                        messageContextMenu.close()
+                    }
                 }
             }
         }

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -126,6 +126,7 @@ DISTFILES += \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/DateGroup.qml \
+    app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageLoader.qml \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml \
     app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml \


### PR DESCRIPTION
Get emoji reactions and display them on the messages. Updates on add and retraction. Should work when loading new chats, but I couldn't test because of the status-go issue. See below for more details

Do note that there was no design for the desktop version of reactions, so some of the reactions look a bit odd, especially for images. Also, with bubbles, the reaction ends up on top of the date 🤷 

Known issue: status-go version has an issue with saveChat. This is a draft PR because we can't merge until status-go is fixed. It makes joining chats undoable.

![image](https://user-images.githubusercontent.com/11926403/90040598-25774500-dc96-11ea-9316-18ed8cbc18f5.png)

![image](https://user-images.githubusercontent.com/11926403/90040631-2f00ad00-dc96-11ea-9921-cdfbdc840399.png)


