### PR TITLE
fix(AssetSelector): always select first item when selector component …

### DIFF
--- a/ui/shared/AssetSelector.qml
+++ b/ui/shared/AssetSelector.qml
@@ -63,7 +63,7 @@ Item {
             property bool isLastItem: index === assets.rowCount() - 1
 
             Component.onCompleted: {
-                if (!selectedAsset && isFirstItem) {
+                if (isFirstItem) {
                     root.selectedAsset = { address, name, value, symbol, fiatBalanceDisplay, fiatBalance }
                 }
             }


### PR DESCRIPTION
…is completed

This fixes a bug that, when the supplied assets change the AssetSelector resets its
selected asset as well

Previously, it would keep the selected asset around, even when the asset list has changed,
leaving it in an invalid state