### PR TITLE
feat: save collectiblesList to WalletAccount

### DIFF
--- a/src/app/wallet/views/account_list.nim
+++ b/src/app/wallet/views/account_list.nim
@@ -1,7 +1,7 @@
 import NimQml, Tables, random, strformat, json_serialization
 import sequtils as sequtils
 import account_item, asset_list
-from ../../../status/wallet import WalletAccount, Asset
+from ../../../status/wallet import WalletAccount, Asset, CollectibleList
 
 const accountColors* = ["#9B832F", "#D37EF4", "#1D806F", "#FA6565", "#7CDA00", "#887af9", "#8B3131"]
 type
@@ -55,6 +55,21 @@ QtObject:
         return i
       i = i + 1
     return -1
+
+  proc addCollectibleListToAccount*(self: AccountList, index: int, collectibleType: string, collectibles: string) =
+    var i = 0
+    for collectibleList in self.accounts[index].account.collectiblesLists:
+      if collectibleList.collectibleType == collectibleType:
+        self.accounts[index].account.collectiblesLists[i].collectiblesJSON = collectibles
+        return
+      i = i + 1
+
+    self.accounts[index].account.collectiblesLists.add(CollectibleList(
+      collectibleType: collectibleType,
+      collectiblesJSON: collectibles,
+      error: "",
+      loading: 0
+    ))
 
   proc deleteAccountAtIndex*(self: AccountList, index: int) =
     sequtils.delete(self.accounts, index, index)


### PR DESCRIPTION
branched off of https://github.com/status-im/nim-status-client/pull/762

Saves the collectibles in the Wallet account so that when we switch between account and one collectible was already loaded, we don't reload again.