### PR TITLE
fix(Chat): ensure new active channel messages are marked as seen

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -175,6 +175,7 @@ QtObject:
 
     self.activeChannel.setChatItem(selectedChannel)
     self.status.chat.setActiveChannel(selectedChannel.id)
+    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
     self.currentSuggestions.setNewData(self.status.contacts.getContacts())
     self.activeChannelChanged()
 
@@ -205,6 +206,7 @@ QtObject:
   proc setActiveChannel*(self: ChatsView, channel: string) {.slot.} =
     if(channel == ""): return
     self.activeChannel.setChatItem(self.chats.getChannel(self.chats.chats.findIndexById(channel)))
+    discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
     self.currentSuggestions.setNewData(self.status.contacts.getContacts())
     self.activeChannelChanged()
 
@@ -251,6 +253,7 @@ QtObject:
           if not channel.muted:
             self.messageNotificationPushed(msg.chatId, msg.text, msg.messageType, channel.chatType.int, msg.timestamp, msg.identicon, msg.alias)
         else:
+          discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
           self.newMessagePushed()
 
   proc updateUsernames*(self:ChatsView, contacts: seq[Profile]) =

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -263,6 +263,12 @@ proc markAllChannelMessagesRead*(self: ChatModel, chatId: string): JsonNode =
     self.channels[chatId].unviewedMessagesCount = 0
     self.events.emit("channelUpdate", ChatUpdateArgs(messages: @[], chats: @[self.channels[chatId]], contacts: @[]))
 
+proc markMessagesSeen*(self: ChatModel, chatId: string, messageIds: seq[string]): JsonNode =
+  var response = status_chat.markMessagesSeen(chatId, messageIds)
+  result = parseJson(response)
+  if self.channels.hasKey(chatId):
+    self.channels[chatId].unviewedMessagesCount = 0
+    self.events.emit("channelUpdate", ChatUpdateArgs(messages: @[], chats: @[self.channels[chatId]], contacts: @[]))
 
 proc confirmJoiningGroup*(self: ChatModel, chatId: string) =
     var response = status_chat.confirmJoiningGroup(chatId)

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -116,6 +116,9 @@ proc sendStickerMessage*(chatId: string, sticker: Sticker): string =
 proc markAllRead*(chatId: string): string =
   callPrivateRPC("markAllRead".prefix, %* [chatId])
 
+proc markMessagesSeen*(chatId: string, messageIds: seq[string]): string =
+  callPrivateRPC("markMessagesSeen".prefix, %* [chatId, messageIds])
+
 proc confirmJoiningGroup*(chatId: string): string =
   callPrivateRPC("confirmJoiningGroup".prefix, %* [chatId])
 


### PR DESCRIPTION
Also, selecting a channel with unread messages marks them as seen as well

Closes #738