### PR TITLE
feat: replace emoji code with correct emoji code point

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
@@ -123,7 +123,7 @@ Rectangle {
             }
             return true;
         } else if (emojiEvent && isKeyValid(event.key) && !isColonPressed) {
-            console.log('popup');
+            // popup
             return true;
         } else if (emojiEvent && !isKeyValid(event.key) && !isColonPressed) {
             return false;

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
@@ -16,6 +16,8 @@ Rectangle {
 
     visible: chatsModel.activeChannel.chatType !== Constants.chatTypePrivateGroupChat || chatsModel.activeChannel.isMember(profileModel.profile.pubKey)
 
+    property bool emojiEvent: false;
+
     Audio {
         id: sendMessageSound
         source: "../../../../sounds/send_message.wav"
@@ -53,6 +55,62 @@ Rectangle {
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             sendMsg(event);
         }
+
+        emojiEvent = emojiHandler(emojiEvent, event);
+    }
+
+
+    function emojiHandler(emojiEvent, event) {
+
+        var msg = chatsModel.plainText(Emoji.deparse(txtData.text).trim());
+
+        if (emojiEvent == false && event.key == Qt.Key_Colon) {
+            if (isSpace(msg.charAt(msg.length - 1)) == true) {
+                console.log('emoji event');
+                return true;
+            }
+            return false;
+        } else if (emojiEvent == true && isKeyValid(event.key) == true) {
+            console.log('popup');
+            return true;
+        } else if (emojiEvent == true && event.key == Qt.Key_Colon) {
+            var index = msg.indexOf(':', 0);
+            txtData.remove(index - 1, txtData.length);
+            txtData.insert(txtData.length, " EMOJI");
+
+            if (event) event.accepted = true;
+
+            return false;
+        } else if (emojiEvent == true && isKeyValid(event.key) == false) {
+            console.log('emoji event stopped');
+            return false;
+        }
+
+        return false;
+    }
+
+    function isKeyValid(key) {
+        if (isKeyAlpha(key) == true || isKeyDigit(key) == true || key == Qt.Key_Underscore || key == Qt.Key_Shift)
+            return true;
+        return false;
+    }
+
+    function isSpace(c) {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+            return true
+        return false
+    }
+
+    function isKeyAlpha(key) {
+        if (key >= Qt.Key_A && key <= Qt.Key_Z)
+            return true;
+        return false;
+    }
+
+    function isKeyDigit(key) {
+        if (key >= Qt.Key_0 && key <= Qt.Key_9)
+            return true;
+        return false;
     }
 
     FileDialog {

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatInput.qml
@@ -6,6 +6,7 @@ import QtQuick.Dialogs 1.0
 import "../components"
 import "../../../../shared"
 import "../../../../imports"
+import "../components/emojiList.js" as EmojiJSON
 
 Rectangle {
     id: rectangle
@@ -55,33 +56,55 @@ Rectangle {
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             sendMsg(event);
         }
+    }
 
+    function onRelease(event) {
         emojiEvent = emojiHandler(emojiEvent, event);
     }
 
+    function onMouseClicked() {
+        emojiEvent = emojiHandler(emojiEvent, {key: null});
+    }
 
     function emojiHandler(emojiEvent, event) {
-
         var msg = chatsModel.plainText(Emoji.deparse(txtData.text).trim());
 
-        if (emojiEvent == false && event.key == Qt.Key_Colon) {
-            if (isSpace(msg.charAt(msg.length - 1)) == true) {
-                console.log('emoji event');
+        // check if user has placed cursor near valid emoji colon token
+        var index = msg.lastIndexOf(':', txtData.cursorPosition);
+        if (index > 0) {
+            var substr = msg.substr(index, txtData.cursorPosition - index);
+            console.log("MESSAGE: ", msg, txtData.cursorPosition, index, substr, validSubstr(substr));
+            emojiEvent = validSubstr(substr)
+        } 
+
+        console.log("EVENT: ", event.key, Qt.Key_Colon, event.key === Qt.Key_Colon, emojiEvent);
+
+        // state machine to handle different forms of the emoji event state
+        if (emojiEvent === false && event.key === Qt.Key_Colon) {
+            if (msg.length <= 1 || isSpace(msg.charAt(txtData.cursorPosition - 1)) === true) {
                 return true;
             }
             return false;
-        } else if (emojiEvent == true && isKeyValid(event.key) == true) {
+        } else if (emojiEvent === true && event.key === Qt.Key_Colon) {
+            var index = msg.lastIndexOf(':', txtData.cursorPosition - 2);
+            if (index >= 0) {
+                var shortname = msg.substr(index, txtData.cursorPosition);
+                var codePoint = getEmojiUnicodeFromShortname(shortname);
+                var newText = (codePoint !== undefined) ? Emoji.fromCodePoint(codePoint) : shortname;
+
+                txtData.remove(index, txtData.cursorPosition);
+                txtData.insert(index, newText);
+
+                if (event) event.accepted = true;
+                return false;
+            }
+            return true;
+        } else if (emojiEvent === true && isKeyValid(event.key) === true) {
             console.log('popup');
             return true;
-        } else if (emojiEvent == true && event.key == Qt.Key_Colon) {
-            var index = msg.indexOf(':', 0);
-            txtData.remove(index - 1, txtData.length);
-            txtData.insert(txtData.length, " EMOJI");
+        } 
 
-            if (event) event.accepted = true;
-
-            return false;
-        } else if (emojiEvent == true && isKeyValid(event.key) == false) {
+        else if (emojiEvent === true && isKeyValid(event.key) === false) {
             console.log('emoji event stopped');
             return false;
         }
@@ -89,16 +112,36 @@ Rectangle {
         return false;
     }
 
+    function validSubstr(substr) {
+        for(var i = 0; i < substr.length; i++) {
+            var c = substr.charAt(i);
+            if (isSpace(c) === true || isPunct(c) === true)
+                return false;
+        }
+        return true;
+    }
+
     function isKeyValid(key) {
-        if (isKeyAlpha(key) == true || isKeyDigit(key) == true || key == Qt.Key_Underscore || key == Qt.Key_Shift)
-            return true;
-        return false;
+        if (key === Qt.Key_Space || key ===  Qt.Key_Tab ||
+            (key >= Qt.Key_Exclam && key <= Qt.Key_Slash) || 
+            (key >= Qt.Key_Semicolon && key <= Qt.Key_Question) ||
+            (key >= Qt.Key_BracketLeft && key <= Qt.Key_hyphen))
+        {
+            return false;
+        }
+        return true;
     }
 
     function isSpace(c) {
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
+        if (/( |\t|\n|\r)/.test(c))
             return true
         return false
+    }
+
+    function isPunct(c) {
+        if (/(!|\@|#|\$|%|\^|&|\*|\(|\)|_|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c))
+            return true;
+        return false;
     }
 
     function isKeyAlpha(key) {
@@ -111,6 +154,19 @@ Rectangle {
         if (key >= Qt.Key_0 && key <= Qt.Key_9)
             return true;
         return false;
+    }
+
+    // search for shortname
+    function getEmojiUnicodeFromShortname(shortname) {
+        var _emoji;
+        EmojiJSON.emoji_json.forEach(function(emoji) {
+            if (emoji.shortname === shortname)
+                _emoji = emoji;
+        })
+
+        if (_emoji !== undefined)
+            return _emoji.unicode;
+        return undefined;
     }
 
     FileDialog {
@@ -151,8 +207,14 @@ Rectangle {
             //% "Type a message..."
             placeholderText: qsTrId("type-a-message")
             Keys.onPressed: onEnter(event)
+            Keys.onReleased: onRelease(event) // gives much more up to date cursorPosition
             background: Rectangle {
                 color: Style.current.transparent
+            }
+
+            TapHandler {
+                id: mousearea
+                onTapped: onMouseClicked()
             }
         }
     }

--- a/ui/imports/Emoji.qml
+++ b/ui/imports/Emoji.qml
@@ -2,6 +2,7 @@ pragma Singleton
 
 import QtQuick 2.13
 import "./twemoji/twemoji.js" as Twemoji
+import "../app/AppLayouts/Chat/components/emojiList.js" as EmojiJSON
 
 QtObject {
     property string base: Qt.resolvedUrl("twemoji/")
@@ -17,8 +18,25 @@ QtObject {
     function deparse(value){
         return value.replace(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" \/>/g, "$1");
     }
+    function deparseFromParse(value) {
+        return value.replace(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?"\/>/g, "$1");
+    }
     function hasEmoji(value) {
         let match = value.match(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" \/>/g)
         return match && match.length > 0
+    }
+    function getEmojis(value) {
+        return value.match(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?"\/>/g, "$1");
+    }
+    function getEmojiUnicode(shortname) {
+        var _emoji;
+        EmojiJSON.emoji_json.forEach(function(emoji) {
+            if (emoji.shortname === shortname)
+                _emoji = emoji;
+        })
+
+        if (_emoji !== undefined)
+            return _emoji.unicode;
+        return undefined;
     }
 }


### PR DESCRIPTION
Hey @emizzle @PascalPrecht @richard-ramos @iurimatias 
I've made a PR that fixes https://github.com/status-im/nim-status-client/issues/800 
Can you please review?

- typing the chars `:joy:` will be replaced with the corresponding emoji
- you can do this at any position in the text
- when you paste the chars `:joy:` it will be replaced with the corresponding emoji
- if the emoji string is not found or the token doesn't match the required format no replacements will be done

The above is made possible with any emoji state machine which checks the text before the cursor for matching tokens like `:joy:` in order to decide to convert them or not.

Note: I've left one state event open for implementation of interacting with the emoji popup

### test
![gif](https://i.imgur.com/2d4Bj89.gif)