### PR TITLE
fix: transaction history handling

### DIFF
--- a/src/app/wallet/core.nim
+++ b/src/app/wallet/core.nim
@@ -47,9 +47,15 @@ proc init*(self: WalletController) =
 
   self.status.events.on(SignalType.Wallet.event) do(e:Args):
     var data = WalletSignal(e)
-    if data.eventType == "newblock":
-      for acc in data.accounts:
-        self.status.wallet.updateAccount(acc)
-        # TODO: show notification
-    # TODO: data.eventType == history, reorg, recent-history-fetching, recent-history-ready:
+    case data.eventType:
+      of "newblock":
+        for acc in data.accounts:
+          self.status.wallet.updateAccount(acc)
+          # TODO: show notification
+      of "recent-history-fetching":
+        self.view.setHistoryFetchState(data.accounts, true)
+      of "recent-history-ready":
+        self.view.setHistoryFetchState(data.accounts, false)
+
+    # TODO: handle these data.eventType: history, reorg
     # see status-react/src/status_im/ethereum/subscriptions.cljs

--- a/ui/app/AppLayouts/Wallet/HistoryTab.qml
+++ b/ui/app/AppLayouts/Wallet/HistoryTab.qml
@@ -5,6 +5,14 @@ import "../../../imports"
 import "../../../shared"
 
 Item {
+    function checkIfHistoryIsBeingFetched(){
+      if(walletModel.isFetchingHistory(walletModel.currentAccount.address)){
+        loadingImg.active = true;
+      } else {
+        walletModel.loadTransactionsForAccount(walletModel.currentAccount.address)
+      }
+    }
+
     Loader {
         id: loadingImg
         active: false
@@ -22,6 +30,7 @@ Item {
 
     Connections {
         target: walletModel
+        onHistoryWasFetched: checkIfHistoryIsBeingFetched()
         onLoadingTrxHistory: {
             loadingImg.active = isLoading
         }

--- a/ui/app/AppLayouts/Wallet/LeftTab.qml
+++ b/ui/app/AppLayouts/Wallet/LeftTab.qml
@@ -14,6 +14,7 @@ Item {
         }
         selectedAccount = newIndex
         walletModel.setCurrentAccountByIndex(newIndex)
+        walletTabBar.currentIndex = 0;
     }
     id: walletInfoContainer
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -87,9 +87,7 @@ SplitView {
                         anchors.leftMargin: 32
                         //% "History"
                         btnText: qsTrId("history")
-                        onClicked: {
-                          walletModel.loadTransactionsForAccount(walletModel.currentAccount.address)
-                        }
+                        onClicked: historyTab.checkIfHistoryIsBeingFetched()
                     }
                 }
 

--- a/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesContent.qml
@@ -86,6 +86,8 @@ ScrollView {
                         height: root.imageSize
                         z: 1
                         source: modelData.image
+                        sourceSize.width: width
+                        sourceSize.height: height
                         fillMode: Image.PreserveAspectCrop
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesModalContent.qml
@@ -18,6 +18,8 @@ Item {
         height: 248
         anchors.horizontalCenter: parent.horizontalCenter
         source: root.collectibleImage
+        sourceSize.width: width
+        sourceSize.height: height
         fillMode: Image.PreserveAspectCrop
     }
 


### PR DESCRIPTION
- Determine if the recent transaction history is being fetched or available before obtaining the first 20 transactions
- On account change, reset the selected tab to show the asset list
- Collectibles were kinda pixelated/blurry (not anymore)

Fixes #806