### PR TITLE
feat: change title from Nim Status Client to Status Desktop

### DIFF
--- a/nim-status.desktop
+++ b/nim-status.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Nim Status Client
+Name=Status Desktop
 Exec=nim_status_client
 Icon=status
 Comment=Hello World

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -24,7 +24,7 @@ proc mainProc() =
   enableHDPI()
   initializeOpenGL()
 
-  let app = newQApplication("Nim Status Client")
+  let app = newQApplication("Status Desktop")
   let resources =
     if defined(windows) and getEnv("NIM_STATUS_CLIENT_DEV").string == "":
       "/../resources/resources.rcc"

--- a/ui/i18n/base.ts
+++ b/ui/i18n/base.ts
@@ -954,7 +954,7 @@ packs will not need to be re-purchased.</source>
     </message>
     <message id="nim-status-client">
         <location filename="../main.qml" line="29"/>
-        <source>Nim Status Client</source>
+        <source>Status Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="quit">

--- a/ui/i18n/base.ts
+++ b/ui/i18n/base.ts
@@ -952,7 +952,7 @@ packs will not need to be re-purchased.</source>
         <source>Monday</source>
         <translation type="unfinished"></translation>
     </message>
-    <message id="nim-status-client">
+    <message id="status-desktop">
         <location filename="../main.qml" line="29"/>
         <source>Status Desktop</source>
         <translation type="unfinished"></translation>

--- a/ui/i18n/qml_af.ts
+++ b/ui/i18n/qml_af.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_af.ts
+++ b/ui/i18n/qml_af.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ar.ts
+++ b/ui/i18n/qml_ar.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_ar.ts
+++ b/ui/i18n/qml_ar.ts
@@ -1009,7 +1009,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_bel.ts
+++ b/ui/i18n/qml_bel.ts
@@ -1286,7 +1286,7 @@
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="23"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_bel.ts
+++ b/ui/i18n/qml_bel.ts
@@ -1284,7 +1284,7 @@
             <source/>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="23"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_cs.ts
+++ b/ui/i18n/qml_cs.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_da.ts
+++ b/ui/i18n/qml_da.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_da.ts
+++ b/ui/i18n/qml_da.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_de.ts
+++ b/ui/i18n/qml_de.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_de.ts
+++ b/ui/i18n/qml_de.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_de_ch.ts
+++ b/ui/i18n/qml_de_ch.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_de_ch.ts
+++ b/ui/i18n/qml_de_ch.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_el.ts
+++ b/ui/i18n/qml_el.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_el.ts
+++ b/ui/i18n/qml_el.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -1072,8 +1072,8 @@ packs will not need to be re-purchased.</translation>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
-            <translation>Nim Status Client</translation>
+            <source>Status Desktop</source>
+            <translation>Status Desktop</translation>
         </message>
         <message id="quit">
             <location filename="../main.qml" line="81"/>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -1070,7 +1070,7 @@ packs will not need to be re-purchased.</translation>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation>Status Desktop</translation>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_es_419.ts
+++ b/ui/i18n/qml_es_419.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_es_419.ts
+++ b/ui/i18n/qml_es_419.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_es_ar.ts
+++ b/ui/i18n/qml_es_ar.ts
@@ -1006,7 +1006,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_es_ar.ts
+++ b/ui/i18n/qml_es_ar.ts
@@ -1008,7 +1008,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_es_mx.ts
+++ b/ui/i18n/qml_es_mx.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_es_mx.ts
+++ b/ui/i18n/qml_es_mx.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fa.ts
+++ b/ui/i18n/qml_fa.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fa.ts
+++ b/ui/i18n/qml_fa.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fi.ts
+++ b/ui/i18n/qml_fi.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fi.ts
+++ b/ui/i18n/qml_fi.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fil.ts
+++ b/ui/i18n/qml_fil.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fil.ts
+++ b/ui/i18n/qml_fil.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fr_ch.ts
+++ b/ui/i18n/qml_fr_ch.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fr_ch.ts
+++ b/ui/i18n/qml_fr_ch.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_fy.ts
+++ b/ui/i18n/qml_fy.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_fy.ts
+++ b/ui/i18n/qml_fy.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_he.ts
+++ b/ui/i18n/qml_he.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_he.ts
+++ b/ui/i18n/qml_he.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_hi.ts
+++ b/ui/i18n/qml_hi.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_hi.ts
+++ b/ui/i18n/qml_hi.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_hu.ts
+++ b/ui/i18n/qml_hu.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_hu.ts
+++ b/ui/i18n/qml_hu.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_id.ts
+++ b/ui/i18n/qml_id.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_id.ts
+++ b/ui/i18n/qml_id.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_it.ts
+++ b/ui/i18n/qml_it.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_it.ts
+++ b/ui/i18n/qml_it.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_it_ch.ts
+++ b/ui/i18n/qml_it_ch.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_it_ch.ts
+++ b/ui/i18n/qml_it_ch.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ja.ts
+++ b/ui/i18n/qml_ja.ts
@@ -987,7 +987,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>ナンス</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_ja.ts
+++ b/ui/i18n/qml_ja.ts
@@ -989,7 +989,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_la.ts
+++ b/ui/i18n/qml_la.ts
@@ -1286,7 +1286,7 @@
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="23"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_la.ts
+++ b/ui/i18n/qml_la.ts
@@ -1284,7 +1284,7 @@
             <source/>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="23"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_lt.ts
+++ b/ui/i18n/qml_lt.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_lt.ts
+++ b/ui/i18n/qml_lt.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_lv.ts
+++ b/ui/i18n/qml_lv.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_lv.ts
+++ b/ui/i18n/qml_lv.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ms.ts
+++ b/ui/i18n/qml_ms.ts
@@ -971,7 +971,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ms.ts
+++ b/ui/i18n/qml_ms.ts
@@ -969,7 +969,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_nb.ts
+++ b/ui/i18n/qml_nb.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_nb.ts
+++ b/ui/i18n/qml_nb.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ne.ts
+++ b/ui/i18n/qml_ne.ts
@@ -971,7 +971,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ne.ts
+++ b/ui/i18n/qml_ne.ts
@@ -969,7 +969,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_nl.ts
+++ b/ui/i18n/qml_nl.ts
@@ -975,7 +975,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_nl.ts
+++ b/ui/i18n/qml_nl.ts
@@ -973,7 +973,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_pl.ts
+++ b/ui/i18n/qml_pl.ts
@@ -971,7 +971,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_pl.ts
+++ b/ui/i18n/qml_pl.ts
@@ -969,7 +969,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_pt.ts
+++ b/ui/i18n/qml_pt.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_pt.ts
+++ b/ui/i18n/qml_pt.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_pt_BR.ts
+++ b/ui/i18n/qml_pt_BR.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_pt_BR.ts
+++ b/ui/i18n/qml_pt_BR.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_pt_pt.ts
+++ b/ui/i18n/qml_pt_pt.ts
@@ -981,7 +981,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Mientras tanto</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_pt_pt.ts
+++ b/ui/i18n/qml_pt_pt.ts
@@ -983,7 +983,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ro.ts
+++ b/ui/i18n/qml_ro.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_ro.ts
+++ b/ui/i18n/qml_ro.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ru.ts
+++ b/ui/i18n/qml_ru.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ru.ts
+++ b/ui/i18n/qml_ru.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sl.ts
+++ b/ui/i18n/qml_sl.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sl.ts
+++ b/ui/i18n/qml_sl.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_sr_rs_cyrl.ts
+++ b/ui/i18n/qml_sr_rs_cyrl.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sr_rs_cyrl.ts
+++ b/ui/i18n/qml_sr_rs_cyrl.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_sr_rs_latn.ts
+++ b/ui/i18n/qml_sr_rs_latn.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sr_rs_latn.ts
+++ b/ui/i18n/qml_sr_rs_latn.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_sv.ts
+++ b/ui/i18n/qml_sv.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sv.ts
+++ b/ui/i18n/qml_sv.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_sw.ts
+++ b/ui/i18n/qml_sw.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_sw.ts
+++ b/ui/i18n/qml_sw.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_th.ts
+++ b/ui/i18n/qml_th.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_th.ts
+++ b/ui/i18n/qml_th.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_tr.ts
+++ b/ui/i18n/qml_tr.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_tr.ts
+++ b/ui/i18n/qml_tr.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>Nonce</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_uk.ts
+++ b/ui/i18n/qml_uk.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_ur.ts
+++ b/ui/i18n/qml_ur.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_ur.ts
+++ b/ui/i18n/qml_ur.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_vi.ts
+++ b/ui/i18n/qml_vi.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_vi.ts
+++ b/ui/i18n/qml_vi.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh.ts
+++ b/ui/i18n/qml_zh.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh.ts
+++ b/ui/i18n/qml_zh.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_Hans_CN.ts
+++ b/ui/i18n/qml_zh_Hans_CN.ts
@@ -997,7 +997,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_Hans_CN.ts
+++ b/ui/i18n/qml_zh_Hans_CN.ts
@@ -995,7 +995,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>随机数</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_TW.ts
+++ b/ui/i18n/qml_zh_TW.ts
@@ -1007,7 +1007,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_TW.ts
+++ b/ui/i18n/qml_zh_TW.ts
@@ -1005,7 +1005,7 @@ packs will not need to be re-purchased.</source>
             <source/>
             <translation/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_hans.ts
+++ b/ui/i18n/qml_zh_hans.ts
@@ -989,7 +989,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_hans.ts
+++ b/ui/i18n/qml_zh_hans.ts
@@ -987,7 +987,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>随机数</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_hant.ts
+++ b/ui/i18n/qml_zh_hant.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_hant.ts
+++ b/ui/i18n/qml_zh_hant.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>隨機數</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_hant_hk.ts
+++ b/ui/i18n/qml_zh_hant_hk.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_hant_hk.ts
+++ b/ui/i18n/qml_zh_hant_hk.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>隨機數</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_hant_sg.ts
+++ b/ui/i18n/qml_zh_hant_sg.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_hant_sg.ts
+++ b/ui/i18n/qml_zh_hant_sg.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>隨機數</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_hant_tw.ts
+++ b/ui/i18n/qml_zh_hant_tw.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_hant_tw.ts
+++ b/ui/i18n/qml_zh_hant_tw.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation>隨機數</translation>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_wuu.ts
+++ b/ui/i18n/qml_zh_wuu.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_wuu.ts
+++ b/ui/i18n/qml_zh_wuu.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/i18n/qml_zh_yue.ts
+++ b/ui/i18n/qml_zh_yue.ts
@@ -961,7 +961,7 @@ packs will not need to be re-purchased.</source>
             <source>Nonce</source>
             <translation type="unfinished"/>
         </message>
-        <message id="nim-status-client">
+        <message id="status-desktop">
             <location filename="../main.qml" line="29"/>
             <source>Status Desktop</source>
             <translation type="unfinished"/>

--- a/ui/i18n/qml_zh_yue.ts
+++ b/ui/i18n/qml_zh_yue.ts
@@ -963,7 +963,7 @@ packs will not need to be re-purchased.</source>
         </message>
         <message id="nim-status-client">
             <location filename="../main.qml" line="29"/>
-            <source>Nim Status Client</source>
+            <source>Status Desktop</source>
             <translation type="unfinished"/>
         </message>
         <message id="quit">

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -25,8 +25,8 @@ ApplicationWindow {
     color: Style.current.background
     title: {
         // Set application settings
-        //% "Nim Status Client"
-        Qt.application.name = qsTrId("nim-status-client")
+        //% "Status Desktop"
+        Qt.application.name = qsTrId("status-desktop")
         Qt.application.organization = "Status"
         Qt.application.domain = "status.im"
         return Qt.application.name


### PR DESCRIPTION
fixes https://github.com/status-im/nim-status-client/issues/392

Change the title "Nim Status Client" to "Status Desktop in the translations, `main.qml` and `nim-status.desktop` files