### PR TITLE
sign-macos-pkg.sh: don't restore Jenkins secret keychains

### DIFF
--- a/scripts/sign-macos-pkg.sh
+++ b/scripts/sign-macos-pkg.sh
@@ -51,7 +51,8 @@ if [[ -n "${MACOS_KEYCHAIN_FILE}" ]]; then
         exit 1
     fi
     echo -e "\n### Storing original keychain search list..."
-    ORIG_KEYCHAIN_LIST=$(security list-keychains | grep -v "^/private" | xargs)
+    # We want to restore the normal keychains and ignore Jenkis created ones
+    ORIG_KEYCHAIN_LIST=$(security list-keychains | grep -v -e "^/private" -e "secretFiles" | xargs)
     
     # The keychain file needs to be locked afterwards
     trap clean_up EXIT ERR


### PR DESCRIPTION
Right now I can find old non-existent keychains from previous builds in keychain search list, like so:
```
jenkins@macos-02.ms-eu-dublin.ci.misc:~ % security list-keychains | grep -v "^/private"  
    "/Users/jenkins/Library/Keychains"
    "/Users/jenkins/Library/Keychains/login.keychain-db"
    "/Users/jenkins/workspace/nim-status-client_macos_PR-728@tmp/secretFiles/1689603e-2878-454f-b0c6-319f6b842138/nim-status-client.keychain-db"
    "/Users/jenkins/workspace/nim-status-client_macos_PR-749@tmp/secretFiles/b1821a37-09e8-45bd-9811-a9b88b658bd8/nim-status-client.keychain-db"
    "/Library/Keychains/System.keychain"
```