### PR TITLE
feat: enable token transactions

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, sequtils, chronicles, times, re, sugar, strutils, os, strformat
+import NimQml, Tables, json, sequtils, chronicles, times, re, sugar, strutils, os
 import ../../status/status
 import ../../status/mailservers
 import ../../status/stickers
@@ -105,17 +105,18 @@ QtObject:
   QtProperty[QVariant] stickerMarketAddress:
     read = getStickerMarketAddress
 
-  proc getStickerBuyPackGasEstimate*(self: ChatsView, packId: int, address: string, price: string): string {.slot.} =
+  proc buyPackGasEstimate*(self: ChatsView, packId: int, address: string, price: string): int {.slot.} =
     try:
-      result = self.status.stickers.buyPackGasEstimate(packId, address, price)
+      result = self.status.stickers.estimateGas(packId, address, price)
     except:
-      result = "400000"
+      result = 325000
 
   proc buyStickerPack*(self: ChatsView, packId: int, address: string, price: string, gas: string, gasPrice: string, password: string): string {.slot.} =
     try:
-      result = $(%self.status.stickers.buyStickerPack(packId, address, price, gas, gasPrice, password))
+      let response = self.status.stickers.buyPack(packId, address, price, gas, gasPrice, password)
+      result = $(%* { "result": %response })
     except RpcException as e:
-      result = fmt"""{{ "error": {{ "message": "{e.msg}" }} }}"""
+      result = $(%* { "error": %* { "message": %e.msg }})
 
   proc obtainAvailableStickerPacks*(self: ChatsView) =
     spawnAndSend(self, "setAvailableStickerPacks") do:

--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -1,6 +1,7 @@
 import NimQml, Tables, strformat, strutils, chronicles, json, std/wrapnils, parseUtils, stint, tables
 import ../../status/[status, wallet, threads]
 import ../../status/wallet/collectibles as status_collectibles
+import ../../status/libstatus/accounts/constants
 import ../../status/libstatus/wallet as status_wallet
 import ../../status/libstatus/tokens
 import ../../status/libstatus/types
@@ -84,7 +85,7 @@ QtObject:
     read = getSigningPhrase
     notify = signingPhraseChanged
 
-  proc getStatusTokenSymbol*(self: WalletView): string {.slot.} = self.status.wallet.getStatusTokenSymbol
+  proc getStatusToken*(self: WalletView): string {.slot.} = self.status.wallet.getStatusToken
 
   proc setCurrentAssetList*(self: WalletView, assetList: seq[Asset])
 
@@ -235,12 +236,28 @@ QtObject:
   QtProperty[QVariant] accounts:
     read = getAccountList
     notify = accountListChanged
+  
+  proc estimateGas*(self: WalletView, from_addr: string, to: string, assetAddress: string, value: string): string {.slot.} =
+    try:
+      var response: int
+      if assetAddress != ZERO_ADDRESS and not assetAddress.isEmptyOrWhitespace:
+        response = self.status.wallet.estimateTokenGas(from_addr, to, assetAddress, value)
+      else:
+        response = self.status.wallet.estimateGas(from_addr, to, value)
+      result = $(%* { "result": %response })
+    except RpcException as e:
+      result = $(%* { "error": %* { "message": %e.msg }})
 
   proc sendTransaction*(self: WalletView, from_addr: string, to: string, assetAddress: string, value: string, gas: string, gasPrice: string, password: string): string {.slot.} =
     try:
-      result = $(%self.status.wallet.sendTransaction(from_addr, to, assetAddress, value, gas, gasPrice, password))
+      var response = ""
+      if assetAddress != ZERO_ADDRESS and not assetAddress.isEmptyOrWhitespace:
+        response = self.status.wallet.sendTokenTransaction(from_addr, to, assetAddress, value, gas, gasPrice, password)
+      else:
+        response = self.status.wallet.sendTransaction(from_addr, to, value, gas, gasPrice, password)
+      result = $(%* { "result": %response })
     except RpcException as e:
-      result = fmt"""{{ "error": {{ "message": "{e.msg}" }} }}"""
+      result = $(%* { "error": %* { "message": %e.msg }})
 
   proc getDefaultAccount*(self: WalletView): string {.slot.} =
     self.currentAccount.address

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -1,9 +1,8 @@
-import eventemitter, json, strutils, sequtils, tables, chronicles, sugar, times
-import libstatus/contracts as status_contracts
+import eventemitter, json, strutils, sequtils, tables, chronicles, times
 import libstatus/chat as status_chat
 import libstatus/mailservers as status_mailservers
 import libstatus/types
-import mailservers, stickers
+import stickers
 import profile/profile
 import chat/[chat, message]
 import signals/messages

--- a/src/status/ens.nim
+++ b/src/status/ens.nim
@@ -12,7 +12,7 @@ import stew/byteutils
 import unicode
 import algorithm
 import eth/common/eth_types, stew/byteutils
-import libstatus/contracts
+import libstatus/eth/contracts
 const domain* = ".stateofus.eth"
 
 proc userName*(ensName: string, removeSuffix: bool = false): string =

--- a/src/status/libstatus/coder.nim
+++ b/src/status/libstatus/coder.nim
@@ -194,3 +194,7 @@ func decode*[T](input: string, to: seq[T]): seq[T] =
 func decode*[T; I: static int](input: string, to: array[0..I, T]): array[0..I, T] =
   for i in 0..I:
     result[i] = input[i*64 .. (i+1)*64].decode(T)
+
+func decodeContractResponse*[T](input: string): T =
+  result = T()
+  discard decode(input.strip0xPrefix, 0, result)

--- a/src/status/libstatus/eth/eth.nim
+++ b/src/status/libstatus/eth/eth.nim
@@ -1,0 +1,10 @@
+import
+  transactions, ../types
+
+proc sendTransaction*(tx: var EthSend, password: string): string =
+  let response = transactions.sendTransaction(tx, password)
+  result = response.result
+
+proc estimateGas*(tx: var EthSend): string =
+  let response = transactions.estimateGas(tx)
+  result = response.result

--- a/src/status/libstatus/eth/methods.nim
+++ b/src/status/libstatus/eth/methods.nim
@@ -1,0 +1,55 @@
+import
+  strutils, options
+
+import
+  nimcrypto, eth/common/eth_types
+
+import 
+  ../coder, eth, transactions, ../types
+
+export sendTransaction
+
+type Method* = object
+  name*: string
+  signature*: string
+
+proc encodeMethod(self: Method): string =
+  ($nimcrypto.keccak256.digest(self.signature))[0..<8].toLower
+
+proc encodeAbi*(self: Method, obj: object = RootObj()): string =
+  result = "0x" & self.encodeMethod()
+
+  # .fields is an iterator, and there's no way to get a count of an iterator
+  # in nim, so we have to loop and increment a counter
+  var fieldCount = 0
+  for i in obj.fields:
+    fieldCount += 1
+  var
+    offset = 32*fieldCount
+    data = ""
+
+  for field in obj.fields:
+    let encoded = encode(field)
+    if encoded.dynamic:
+      result &= offset.toHex(64).toLower
+      data &= encoded.data
+      offset += encoded.data.len
+    else:
+      result &= encoded.data
+  result &= data
+
+proc estimateGas*(self: Method, tx: var EthSend, methodDescriptor: object): string =
+  tx.data = self.encodeAbi(methodDescriptor)
+  let response = transactions.estimateGas(tx)
+  result = response.result # gas estimate in hex
+
+proc send*(self: Method, tx: var EthSend, methodDescriptor: object, password: string): string =
+  tx.data = self.encodeAbi(methodDescriptor)
+  result = eth.sendTransaction(tx, password)
+  # result = coder.decodeContractResponse[string](response.result)
+  # result = response.result
+
+proc call*[T](self: Method, tx: var EthSend, methodDescriptor: object): T =
+  tx.data = self.encodeAbi(methodDescriptor)
+  let response = transactions.call(tx)
+  result = coder.decodeContractResponse[T](response.result)

--- a/src/status/libstatus/eth/transactions.nim
+++ b/src/status/libstatus/eth/transactions.nim
@@ -1,0 +1,30 @@
+import
+  json
+
+import
+  json_serialization, chronicles
+
+import
+  ../core, ../types
+
+proc estimateGas*(tx: EthSend): RpcResponse =
+  let response = core.callPrivateRPC("eth_estimateGas", %*[%tx])
+  result = Json.decode(response, RpcResponse)
+  if not result.error.isNil:
+    raise newException(RpcException, "Error getting gas estimate: " & result.error.message)
+
+  trace "Gas estimated succesfully", estimate=result.result
+
+proc sendTransaction*(tx: EthSend, password: string): RpcResponse =
+  let responseStr = core.sendTransaction($(%tx), password)
+  result = Json.decode(responseStr, RpcResponse)
+  if not result.error.isNil:
+    raise newException(RpcException, "Error sending transaction: " & result.error.message)
+
+  trace "Transaction sent succesfully", hash=result.result
+
+proc call*(tx: EthSend): RpcResponse =
+  let responseStr = core.callPrivateRPC("eth_call", %*[%tx])
+  result = Json.decode(responseStr, RpcResponse)
+  if not result.error.isNil:
+    raise newException(RpcException, "Error calling method: " & result.error.message)

--- a/src/status/libstatus/tokens.nim
+++ b/src/status/libstatus/tokens.nim
@@ -1,6 +1,6 @@
 import json, chronicles, strformat, stint, strutils
 import core, wallet
-import contracts
+import ./eth/contracts
 import eth/common/eth_types, eth/common/utils
 import json_serialization
 import settings

--- a/src/status/libstatus/utils.nim
+++ b/src/status/libstatus/utils.nim
@@ -1,5 +1,5 @@
-import json, random, strutils, strformat, tables
-import stint, nim_status
+import json, random, strutils, strformat, tables, unicode
+import stint
 from times import getTime, toUnix, nanosecond
 import accounts/signing_phrases
 
@@ -66,7 +66,7 @@ proc first*(jArray: JsonNode, fieldName, id: string): JsonNode =
   if jArray.kind != JArray:
     raise newException(ValueError, "Parameter 'jArray' is a " & $jArray.kind & ", but must be a JArray")
   for child in jArray.getElems:
-    if child{fieldName}.getStr == id:
+    if child{fieldName}.getStr.toLower == id.toLower:
       return child
 
 proc any*(jArray: JsonNode, fieldName, id: string): bool =
@@ -74,7 +74,7 @@ proc any*(jArray: JsonNode, fieldName, id: string): bool =
     return false
   result = false
   for child in jArray.getElems:
-    if child{fieldName}.getStr == id:
+    if child{fieldName}.getStr.toLower == id.toLower:
       return true
 
 proc isEmpty*(a: JsonNode): bool =

--- a/src/status/libstatus/wallet.nim
+++ b/src/status/libstatus/wallet.nim
@@ -2,7 +2,7 @@ import json, json, options, json_serialization, stint, chronicles
 import core, types, utils, strutils, strformat
 from nim_status import validateMnemonic, startWallet
 import ../wallet/account
-import ./contracts as contractMethods
+import ./eth/contracts as contractMethods
 import eth/common/eth_types
 import ./types
 import ../signals/types as signal_types
@@ -61,14 +61,6 @@ proc getTransfersByAddress*(address: string): seq[types.Transaction] =
   except:
     let msg = getCurrentExceptionMsg()
     error "Failed getting wallet account transactions", msg
-
-proc sendTransaction*(tx: EthSend, password: string): RpcResponse =
-  let responseStr = core.sendTransaction($(%tx), password)
-  result = Json.decode(responseStr, RpcResponse)
-  if not result.error.isNil:
-    raise newException(RpcException, "Error sending transaction: " & result.error.message)
-
-  trace "Transaction sent succesfully", hash=result
 
 proc getBalance*(address: string): string =
   let payload = %* [address, "latest"]

--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -1,16 +1,14 @@
-import
-  tables, strutils, sequtils, sugar
+import # global deps
+  tables, strutils, sequtils, sugar, json
 
-import
+import # project deps
   chronicles, eth/common/eth_types, eventemitter
-
 from eth/common/utils import parseAddress
 
-import
-  libstatus/types, libstatus/stickers as status_stickers,
-  libstatus/contracts as status_contracts
-
-from libstatus/utils as libstatus_utils import eth2Wei, gwei2Wei, toUInt64
+import # local deps
+  libstatus/types, libstatus/eth/contracts as status_contracts,
+  libstatus/stickers as status_stickers, transactions
+from libstatus/utils as libstatus_utils import eth2Wei
 
 logScope:
   topics = "stickers-model"
@@ -43,26 +41,52 @@ proc init*(self: StickersModel) =
     var evArgs = StickerArgs(e)
     self.addStickerToRecent(evArgs.sticker, evArgs.save)
 
-# TODO: Replace this with a more generalised way of estimating gas so can be used for token transfers
-proc buyPackGasEstimate*(self: StickersModel, packId: int, address: string, price: string): string =
+proc buildTransaction(self: StickersModel, packId: Uint256, address: EthAddress, price: Uint256, approveAndCall: var ApproveAndCall, sntContract: var Contract, gas = "", gasPrice = ""): EthSend =
+  sntContract = status_contracts.getContract("snt")
   let
-    priceTyped = eth2Wei(parseFloat(price), 18) # SNT
-    hexGas = status_stickers.buyPackGasEstimate(packId.u256, parseAddress(address), priceTyped)
-  result = $fromHex[int](hexGas)
+    stickerMktContract = status_contracts.getContract("sticker-market")
+    buyToken = BuyToken(packId: packId, address: address, price: price)
+    buyTxAbiEncoded = stickerMktContract.methods["buyToken"].encodeAbi(buyToken)
+  approveAndCall = ApproveAndCall(to: stickerMktContract.address, value: price, data: DynamicBytes[100].fromHex(buyTxAbiEncoded))
+  transactions.buildTokenTransaction(address, sntContract.address, gas, gasPrice)
+
+proc estimateGas*(self: StickersModel, packId: int, address: string, price: string): int =
+  var
+    approveAndCall: ApproveAndCall
+    sntContract = status_contracts.getContract("snt")
+    tx = self.buildTransaction(
+      packId.u256,
+      parseAddress(address),
+      eth2Wei(parseFloat(price), 18), # SNT
+      approveAndCall,
+      sntContract
+    )
+  try:
+    let response = sntContract.methods["approveAndCall"].estimateGas(tx, approveAndCall)
+    result = fromHex[int](response)
+  except RpcException as e:
+    raise
+
+proc buyPack*(self: StickersModel, packId: int, address, price, gas, gasPrice, password: string): string =
+  var
+    sntContract: Contract
+    approveAndCall: ApproveAndCall
+    tx = self.buildTransaction(
+      packId.u256,
+      parseAddress(address),
+      eth2Wei(parseFloat(price), 18), # SNT
+      approveAndCall,
+      sntContract,
+      gas,
+      gasPrice
+    )
+  try:
+    result = sntContract.methods["approveAndCall"].send(tx, approveAndCall, password)
+  except RpcException as e:
+    raise
 
 proc getStickerMarketAddress*(self: StickersModel): EthAddress =
   result = status_contracts.getContract("sticker-market").address
-
-proc buyStickerPack*(self: StickersModel, packId: int, address, price, gas, gasPrice, password: string): RpcResponse =
-  try:
-    let
-      addressTyped = parseAddress(address)
-      priceTyped = eth2Wei(parseFloat(price), 18) # SNT
-      gasTyped = cast[uint64](parseFloat(gas).toUInt64)
-      gasPriceTyped = gwei2Wei(parseFloat(gasPrice)).truncate(int)
-    result = status_stickers.buyPack(packId.u256, addressTyped, priceTyped, gasTyped, gasPriceTyped, password)
-  except RpcException as e:
-    raise
 
 proc getPurchasedStickerPacks*(self: StickersModel, address: EthAddress): seq[int] =
   if self.purchasedStickerPacks != @[]:

--- a/src/status/transactions.nim
+++ b/src/status/transactions.nim
@@ -1,0 +1,23 @@
+import
+  options, strutils
+
+import
+  stint
+from eth/common/eth_types import EthAddress
+from eth/common/utils import parseAddress
+
+import
+  libstatus/types
+from libstatus/utils as status_utils import toUInt64, gwei2Wei
+
+proc buildTransaction*(source: EthAddress, value: Uint256, gas = "", gasPrice = ""): EthSend =
+  result = EthSend(
+    source: source,
+    value: value.some,
+    gas: (if gas.isEmptyOrWhitespace: Quantity.none else: Quantity(cast[uint64](parseFloat(gas).toUInt64)).some),
+    gasPrice: (if gasPrice.isEmptyOrWhitespace: int.none else: gwei2Wei(parseFloat(gasPrice)).truncate(int).some)
+  )
+
+proc buildTokenTransaction*(source, contractAddress: EthAddress, gas = "", gasPrice = ""): EthSend =
+  result = buildTransaction(source, 0.u256, gas, gasPrice)
+  result.to = contractAddress.some

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -1,7 +1,7 @@
 import strformat, httpclient, json, chronicles, sequtils, strutils, tables, sugar
 from eth/common/utils import parseAddress
 import ../libstatus/core as status
-import ../libstatus/contracts as contracts
+import ../libstatus/eth/contracts as contracts
 import ../libstatus/stickers as status_stickers
 import ../chat as status_chat
 import ../libstatus/types

--- a/ui/shared/DebounceTimer.qml
+++ b/ui/shared/DebounceTimer.qml
@@ -1,0 +1,10 @@
+import QtQml 2.13
+
+Timer {
+    id: timerEstimateGas
+    interval: 600
+    function startOrRestartIfRunning() {
+        if (running) return restart()
+        start()
+    }
+}

--- a/ui/shared/GasValidator.qml
+++ b/ui/shared/GasValidator.qml
@@ -37,7 +37,7 @@ Item {
         }
         txtValidationError.text = ""
         let gasTotal = selectedGasEthValue
-        if (selectedAsset && selectedAsset.symbol.toUpperCase() === "ETH") {
+        if (selectedAsset && selectedAsset.symbol && selectedAsset.symbol.toUpperCase() === "ETH") {
             gasTotal += selectedAmount
         }
         const currAcctGasAsset = Utils.findAssetBySymbol(selectedAccount.assets, "ETH")


### PR DESCRIPTION
Fixes #788.
Fixes #853.
Fixes #856.

refactor: gas estimation and transaction sends have been abstracted to  allow calling `estimateGas`, `send`, and `call` on the contract method (similar to the web3 API).

Moved sticker pack gas estimation and purchase tx over to the new API

*Sticker purchase:*
 - gas estimate is done using new API and debounced using a timer

*Wallet send transaction:*
 - tokens can now be sent
 - gas is estimated correctly for a token tx, and debounced using a timer

***NOTE***
1. If attempting to send tokens on testnet, you must use a custom token as the token addresses in the pre-built list are for mainnet and will not work on testnet (open issue for this: https://github.com/status-im/nim-status-client/issues/613).
2. The new API should support most if not all of the existing gas estimates, send txs, and calls (that's the idea anyway). The loading of sticker pack data, balance, count, purchased sticker packs, etc, can be moved over to the new API. Eventually it would be nice if all of the `eth_sendTransaction`, `eth_gasEstimate`, and `eth_call` could be moved over as well.
3. The base branch is a smaller refactor. It's likely better to get that merged in to `master` first, then rebase this branch on top of master.