### PR TITLE
change dynamicbytes to be more dynamic

### DIFF
--- a/src/status/ens.nim
+++ b/src/status/ens.nim
@@ -154,7 +154,7 @@ proc registerUsername*(username:string, address: EthAddress, pubKey: string, pas
   let
     register = Register(label: label, account: address, x: x, y: y)
     registerAbiEncoded = ensUsernamesContract.methods["register"].encodeAbi(register)
-    approveAndCallObj = ApproveAndCall(to: ensUsernamesContract.address, value: price, data: DynamicBytes[100].fromHex(registerAbiEncoded))
+    approveAndCallObj = ApproveAndCall[132](to: ensUsernamesContract.address, value: price, data: DynamicBytes[132].fromHex(registerAbiEncoded))
     approveAndCallAbiEncoded = sntContract.methods["approveAndCall"].encodeAbi(approveAndCallObj)
   
   let payload = %* {

--- a/src/status/libstatus/coder.nim
+++ b/src/status/libstatus/coder.nim
@@ -37,10 +37,10 @@ type
     x*: FixedBytes[32]
     y*: FixedBytes[32]
 
-  ApproveAndCall* = object
+  ApproveAndCall*[N: static[int]] = object
     to*: EthAddress
     value*: Stuint[256]
-    data*: DynamicBytes[100]
+    data*: DynamicBytes[N]
 
   Transfer* = object
     to*: EthAddress

--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -41,18 +41,18 @@ proc init*(self: StickersModel) =
     var evArgs = StickerArgs(e)
     self.addStickerToRecent(evArgs.sticker, evArgs.save)
 
-proc buildTransaction(self: StickersModel, packId: Uint256, address: EthAddress, price: Uint256, approveAndCall: var ApproveAndCall, sntContract: var Contract, gas = "", gasPrice = ""): EthSend =
+proc buildTransaction(self: StickersModel, packId: Uint256, address: EthAddress, price: Uint256, approveAndCall: var ApproveAndCall[100], sntContract: var Contract, gas = "", gasPrice = ""): EthSend =
   sntContract = status_contracts.getContract("snt")
   let
     stickerMktContract = status_contracts.getContract("sticker-market")
     buyToken = BuyToken(packId: packId, address: address, price: price)
     buyTxAbiEncoded = stickerMktContract.methods["buyToken"].encodeAbi(buyToken)
-  approveAndCall = ApproveAndCall(to: stickerMktContract.address, value: price, data: DynamicBytes[100].fromHex(buyTxAbiEncoded))
+  approveAndCall = ApproveAndCall[100](to: stickerMktContract.address, value: price, data: DynamicBytes[100].fromHex(buyTxAbiEncoded))
   transactions.buildTokenTransaction(address, sntContract.address, gas, gasPrice)
 
 proc estimateGas*(self: StickersModel, packId: int, address: string, price: string): int =
   var
-    approveAndCall: ApproveAndCall
+    approveAndCall: ApproveAndCall[100]
     sntContract = status_contracts.getContract("snt")
     tx = self.buildTransaction(
       packId.u256,
@@ -70,7 +70,7 @@ proc estimateGas*(self: StickersModel, packId: int, address: string, price: stri
 proc buyPack*(self: StickersModel, packId: int, address, price, gas, gasPrice, password: string): string =
   var
     sntContract: Contract
-    approveAndCall: ApproveAndCall
+    approveAndCall: ApproveAndCall[100]
     tx = self.buildTransaction(
       packId.u256,
       parseAddress(address),


### PR DESCRIPTION
![more dynamicer](https://tenor.com/view/more-cowbell-cowbell-snl-reaction-mrw-gif-14076918.gif)

Allows `ApproveAndCall` to accept a generic byte-length.

@richard-ramos - please close this if you've incorporated it already