### PR TITLE
feat: show stickers purchased from non-main account

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -127,10 +127,14 @@ QtObject:
       $(%*(packs))
 
   proc setAvailableStickerPacks*(self: ChatsView, availableStickersJSON: string) {.slot.} =
-    let currAcct = status_wallet.getWalletAccounts()[0] # TODO: make generic
-    let currAddr = parseAddress(currAcct.address)
-    let installedStickerPacks = self.status.stickers.getInstalledStickerPacks()
-    let purchasedStickerPacks = self.status.stickers.getPurchasedStickerPacks(currAddr)
+    let
+      accounts = status_wallet.getWalletAccounts() # TODO: make generic
+      installedStickerPacks = self.status.stickers.getInstalledStickerPacks()
+    var
+      purchasedStickerPacks: seq[int]
+    for account in accounts:
+      let address = parseAddress(account.address)
+      purchasedStickerPacks = self.status.stickers.getPurchasedStickerPacks(address)
     let availableStickers = JSON.decode($availableStickersJSON, seq[StickerPack])
 
     for stickerPack in availableStickers:

--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -89,15 +89,12 @@ proc getStickerMarketAddress*(self: StickersModel): EthAddress =
   result = status_contracts.getContract("sticker-market").address
 
 proc getPurchasedStickerPacks*(self: StickersModel, address: EthAddress): seq[int] =
-  if self.purchasedStickerPacks != @[]:
-    return self.purchasedStickerPacks
-
   try:
-    var
+    let
       balance = status_stickers.getBalance(address)
       tokenIds = toSeq[0..<balance].map(idx => status_stickers.tokenOfOwnerByIndex(address, idx.u256))
-
-    self.purchasedStickerPacks = tokenIds.map(tokenId => status_stickers.getPackIdFromTokenId(tokenId.u256))
+      purchasedPackIds = tokenIds.map(tokenId => status_stickers.getPackIdFromTokenId(tokenId.u256))
+    self.purchasedStickerPacks = self.purchasedStickerPacks.concat(purchasedPackIds)
     result = self.purchasedStickerPacks
   except RpcException:
     error "Error getting purchased sticker packs", message = getCurrentExceptionMsg()

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -38,7 +38,7 @@ Item {
         if (showBalanceForAssetSymbol == "" || minRequiredAssetBalance == 0 || !assetFound) {
             return root.isValid
         }
-        root.isValid = assetFound.value > minRequiredAssetBalance
+        root.isValid = assetFound.value >= minRequiredAssetBalance
         return root.isValid
     }
 


### PR DESCRIPTION
Fixes: #815

Previously, only stickers purchased from the main status account were shown. Now, stickers purchased from any of the accounts are shown.

Accounts include any accounts returned by `accounts_getAccounts` and are non-chat accounts.