### PR TITLE
feat: disable selection of "contact" in send modal

### DIFF
--- a/ui/shared/RecipientSelector.qml
+++ b/ui/shared/RecipientSelector.qml
@@ -22,7 +22,7 @@ Item {
     property var reset: function() {}
     readonly property var sources: [
         qsTr("Address"),
-        qsTr("Contact"),
+        // qsTr("Contact"), // disable this tempoarily as we work to enable to sending to contacts
         qsTr("My account")
     ]
 


### PR DESCRIPTION
Disable the selection of "contact" in the send transaction modal, because right now, this is not possible, but it will be in the future. Once we get this working, we can uncomment it.