### PR TITLE
fix(Wallet): derive accounts from imported mnemonic and store correctly

### DIFF
--- a/src/status/libstatus/accounts.nim
+++ b/src/status/libstatus/accounts.nim
@@ -225,7 +225,7 @@ proc storeDerivedWallet*(account: GeneratedAccount, password: string, walletInde
   let hashedPassword = hashPassword(password)
   let multiAccount = %* {
     "accountID": account.id,
-    "paths": ["m/" & $walletIndex],
+    "paths": ["m/44'/60'/0'/0/" & $walletIndex],
     "password": hashedPassword
   }
   let response = parseJson($nim_status.multiAccountStoreDerivedAccounts($multiAccount));

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -186,7 +186,8 @@ proc generateNewAccount*(self: WalletModel, password: string, accountName: strin
 
 proc addAccountsFromSeed*(self: WalletModel, seed: string, password: string, accountName: string, color: string): string =
   let mnemonic = replace(seed, ',', ' ')
-  let generatedAccount = status_accounts.multiAccountImportMnemonic(mnemonic)
+  var generatedAccount = status_accounts.multiAccountImportMnemonic(mnemonic)
+  generatedAccount.derived = status_accounts.deriveAccounts(generatedAccount.id)
   return self.addNewGeneratedAccountWithPassword(generatedAccount, password, accountName, color, constants.SEED)
 
 proc addAccountsFromPrivateKey*(self: WalletModel, privateKey: string, password: string, accountName: string, color: string): string =


### PR DESCRIPTION
This commit address two bugs:

1. When importing a mnemonic, the resulting "master" account and its address
  was used as account to be stored as opposed to its derived default account
2. The account was stored in the wrong path, resulting in status not being able
  to locate accounts when sending transactions.

Fixes #787