### PR TITLE
fix: exception handling in mutli-threaded transactions

### DIFF
--- a/src/status/libstatus/eth/eth.nim
+++ b/src/status/libstatus/eth/eth.nim
@@ -1,10 +1,20 @@
 import
   transactions, ../types
 
-proc sendTransaction*(tx: var EthSend, password: string): string =
-  let response = transactions.sendTransaction(tx, password)
-  result = response.result
+proc sendTransaction*(tx: var EthSend, password: string, success: var bool): string =
+  success = true
+  try:
+    let response = transactions.sendTransaction(tx, password)
+    result = response.result
+  except RpcException as e:
+    success = false
+    result = e.msg
 
-proc estimateGas*(tx: var EthSend): string =
-  let response = transactions.estimateGas(tx)
-  result = response.result
+proc estimateGas*(tx: var EthSend, success: var bool): string =
+  success = true
+  try:
+    let response = transactions.estimateGas(tx)
+    result = response.result
+  except RpcException as e:
+    success = false
+    result = e.msg

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
@@ -40,12 +40,12 @@ ModalPopup {
                                                  transactionSigner.enteredPassword)
         let response = JSON.parse(responseStr)
 
-        if (response.error) {
-            if (response.error.message.includes("could not decrypt key with given password")){
+        if (!response.success) {
+            if (response.result.includes("could not decrypt key with given password")){
                 transactionSigner.validationError = qsTr("Wrong password")
                 return
             }
-            sendingError.text = response.error.message
+            sendingError.text = response.result
             return sendingError.open()
         }
     }
@@ -90,8 +90,8 @@ ModalPopup {
                         root.selectedAsset.address,
                         root.selectedAmount))
 
-                    if (gasEstimate.error) {
-                        console.warn(qsTr("Error estimating gas: %1").arg(gasEstimate.error.message))
+                    if (!gasEstimate.success) {
+                        console.warn(qsTr("Error estimating gas: %1").arg(gasEstimate.result))
                         return
                     }
                     selectedGasLimit = gasEstimate.result

--- a/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
@@ -33,12 +33,12 @@ ModalPopup {
                                                     transactionSigner.enteredPassword)
         let response = JSON.parse(responseStr)
 
-        if (response.error) {
-            if (response.error.message.includes("could not decrypt key with given password")){
+        if (!response.success) {
+            if (response.result.includes("could not decrypt key with given password")){
                 transactionSigner.validationError = qsTr("Wrong password")
                 return
             }
-            sendingError.text = response.error.message
+            sendingError.text = response.result
             return sendingError.open()
         }
     }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
@@ -42,12 +42,12 @@ ModalPopup {
                                                        transactionSigner.enteredPassword)
         let response = JSON.parse(responseStr)
 
-        if (response.error) {
-            if (response.error.message.includes("could not decrypt key with given password")){
+        if (!response.success) {
+            if (response.result.includes("could not decrypt key with given password")){
                 transactionSigner.validationError = qsTr("Wrong password")
                 return
             }
-            sendingError.text = response.error.message
+            sendingError.text = response.result
             return sendingError.open()
         }
 

--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -128,8 +128,8 @@ ModalPopup {
                         txtAmount.selectedAsset.address,
                         txtAmount.selectedAmount))
 
-                    if (gasEstimate.error) {
-                        console.warn(qsTr("Error estimating gas: %1").arg(gasEstimate.error.message))
+                    if (!gasEstimate.success) {
+                        console.warn(qsTr("Error estimating gas: %1").arg(gasEstimate.result))
                         return
                     }
                     selectedGasLimit = gasEstimate.result
@@ -256,12 +256,12 @@ ModalPopup {
                     stack.currentGroup.isPending = false
                     let response = JSON.parse(txResult)
 
-                    if (response.error) {
-                        if (response.error.message.includes("could not decrypt key with given password")){
+                    if (!response.success) {
+                        if (response.result.includes("could not decrypt key with given password")){
                             transactionSigner.validationError = qsTr("Wrong password")
                             return
                         }
-                        sendingError.text = response.error.message
+                        sendingError.text = response.result
                         return sendingError.open()
                     }
 


### PR DESCRIPTION
Currently, exceptions thrown during transactions or gas estimation that were spawned in another thread are not being propagated, due to a limitation in nim (see https://nim-lang.org/docs/manual_experimental.html#parallel-amp-spawn).

This means any exceptions from status-go were not propagated correctly and would cause the app to crash. This includes entering the wrong password when trying to send a transaction.

The issue was addressed by passing a `success` variable by reference, which is set to false if an exception was thrown by status-go.

Another issue was fixed relating to estimating token transaction gas. This was fixed by importing `$` in to the wallet model.