### PR TITLE
fix: fix assets not updating in views when getting new balance

### DIFF
--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -341,6 +341,7 @@ QtObject:
 
   proc updateView*(self: WalletView) =
     self.totalFiatBalanceChanged()
+    self.currentAccount.assetList.setNewData(self.currentAccount.account.assetList)
     self.currentAccountChanged()
     self.accountListChanged()
     self.accounts.forceUpdate()


### PR DESCRIPTION
Fixes #884 

A very fun one liner that ended up costing me multiple hours of time

The issue was that we update the asset in the current account's `assets`, but not in its `assetList`, which is the View for that AssetList