### PR TITLE
fix: call wakuext_contacts RPC once

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -253,10 +253,6 @@ QtObject:
 
     self.activeChannel.setChatItem(selectedChannel)
     self.status.chat.setActiveChannel(selectedChannel.id)
-    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
-    self.currentSuggestions.setNewData(self.status.contacts.getContacts())
-    self.setLastMessageTimestamp(true)
-    self.activeChannelChanged()
 
   proc getActiveChannelIdx(self: ChatsView): QVariant {.slot.} =
     newQVariant(self.chats.chats.findIndexById(self.activeChannel.id))
@@ -289,7 +285,6 @@ QtObject:
     if(channel == ""): return
     self.activeChannel.setChatItem(self.chats.getChannel(self.chats.chats.findIndexById(channel)))
     discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
-    self.currentSuggestions.setNewData(self.status.contacts.getContacts())
     self.setLastMessageTimestamp(true)
     self.activeChannelChanged()
 


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-status-client/issues/665

![](https://i.imgur.com/xLHpWlN.png)

The above diagram details the logic that is executed when a user switches channel. The flow colored in red executes first and then comes the flow colored in blue.

This logic comes from the following function:
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L242

More specifically line 255 through 257 and these lines will remain the basis of this discussion:
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L255-L257

The `setActiveChannel` function executes the following two statements
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L291-L292

`status.chat.markAllMessages` calls the status component which makes the RPC call `wakuext_markAllRead` and when completed emits a "channelUpdate" signal. 
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/status/chat.nim#L242-L247

This signal is picked up by `updateChannel` in event_handling.nim which in turn calls the `updateChats` function that exists back inside app/chat/view.nim. 
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/event_handling.nim#L27-L29

`updateChats` finally calls `currentSuggestions.setNewData(status.contacts.getContacts())`. This makes the RPC call `wakuext_contacts`.
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L508-L515

So far the terminal prints the following output:
```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

Coming back into `setActiveChannel` line 292 now gets executed.
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L292

Which makes the RPC call `wakuext_contacts` the second time. The terminal debug messages now look like this:
```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

Coming back into the main function of this discussion `setActiveChannelByIndex` the following two lines now need to get executed
https://github.com/status-im/nim-status-client/blob/c3d946b16517ce00ab9374c42a361fa923f60ecd/src/app/chat/view.nim#L256-L257

Which repeats the above explained logic and prints the following debug messages the second time.
```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

Resulting in this full debug log
```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

This PR fixes what the issue explains by removing the statements `currentSuggestions.setNewData(status.contacts.getContacts())` within the functions `setActiveChannelById` and `setActiveChannel` since its already called in the `updateChats` function. Making the debug messages look like this:

```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

![](https://i.imgur.com/iiRyqP5.png)

Side effects: I have not noticed any side effects by introducing the fix and the app functions as should i.e switches to relevant channel and marks messages read if there were any new messages.

Notes:
i propose that we remove the 2 lines after `setActiveChannel` ensuring that the RPC calls `wakuext_markAllRead` and `wakuext_contacts` are only called once resulting in the debug:

```
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_markAllRead
topics="rpc" tid=87474 file=core.nim:20 rpc_method=wakuext_contacts
```

![](https://i.imgur.com/tw9t4Ed.png)