### PR TITLE
Add support for local contact nickname

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -513,15 +513,6 @@ QtObject:
   proc renameGroup*(self: ChatsView, newName: string) {.slot.} =
     self.status.chat.renameGroup(self.activeChannel.id, newName)
 
-  proc blockContact*(self: ChatsView, id: string): string {.slot.} =
-    return self.status.contacts.blockContact(id)
-
-  proc addContact*(self: ChatsView, id: string): string {.slot.} =
-    return self.status.contacts.addContact(id)
-
-  proc removeContact*(self: ChatsView, id: string) {.slot.} =
-    self.status.contacts.removeContact(id)
-
   proc createGroup*(self: ChatsView, groupName: string, pubKeys: string) {.slot.} =
     let pubKeysSeq = map(parseJson(pubKeys).getElems(), proc(x:JsonNode):string = x.getStr)
     self.status.chat.createGroup(groupName, pubKeysSeq)

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -276,9 +276,9 @@ QtObject:
         ensVerified: false
       )
     self.contactToAddChanged()
-  
-  proc addContact*(self: ProfileView, pk: string) {.slot.} =
-    discard self.status.contacts.addContact(pk)
+
+  proc addContact*(self: ProfileView, pk: string): string {.slot.} =
+    return self.status.contacts.addContact(pk)
 
   proc changeContactNickname*(self: ProfileView, publicKey: string, nickname: string) {.slot.} =
     discard self.status.contacts.addContact(publicKey, nickname)
@@ -286,8 +286,8 @@ QtObject:
   proc unblockContact*(self: ProfileView, id: string) {.slot.} =
     discard self.status.contacts.unblockContact(id)
 
-  proc blockContact*(self: ProfileView, id: string) {.slot.} =
-    discard self.status.contacts.blockContact(id)
+  proc blockContact*(self: ProfileView, id: string): string {.slot.} =
+    return self.status.contacts.blockContact(id)
 
   proc removeContact*(self: ProfileView, id: string) {.slot.} =
     self.status.contacts.removeContact(id)

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -280,6 +280,9 @@ QtObject:
   proc addContact*(self: ProfileView, pk: string) {.slot.} =
     discard self.status.contacts.addContact(pk)
 
+  proc changeContactNickname*(self: ProfileView, publicKey: string, nickname: string) {.slot.} =
+    discard self.status.contacts.addContact(publicKey, nickname)
+
   proc unblockContact*(self: ProfileView, id: string) {.slot.} =
     discard self.status.contacts.unblockContact(id)
 

--- a/src/app/profile/views/contact_list.nim
+++ b/src/app/profile/views/contact_list.nim
@@ -13,6 +13,7 @@ type
     IsBlocked = UserRole + 6
     Alias = UserRole + 7
     EnsVerified = UserRole + 8
+    LocalNickname = UserRole + 9
 
 QtObject:
   type ContactList* = ref object of QAbstractListModel
@@ -52,6 +53,7 @@ QtObject:
       of "isBlocked": result = $contact.isBlocked()
       of "alias": result = contact.alias
       of "ensVerified": result = $contact.ensVerified
+      of "localNickname": result = $contact.localNickname
 
   method data(self: ContactList, index: QModelIndex, role: int): QVariant =
     if not index.isValid:
@@ -68,6 +70,7 @@ QtObject:
       of ContactRoles.IsBlocked: result = newQVariant(contact.isBlocked())
       of ContactRoles.Alias: result = newQVariant(contact.alias)
       of ContactRoles.EnsVerified: result = newQVariant(contact.ensVerified)
+      of ContactRoles.LocalNickname: result = newQVariant(contact.localNickname)
 
   method roleNames(self: ContactList): Table[int, string] =
     {
@@ -78,6 +81,7 @@ QtObject:
       ContactRoles.IsContact.int:"isContact",
       ContactRoles.IsBlocked.int:"isBlocked",
       ContactRoles.Alias.int:"alias",
+      ContactRoles.LocalNickname.int:"localNickname",
       ContactRoles.EnsVerified.int:"ensVerified"
     }.toTable
 

--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -15,6 +15,7 @@ type ChatMember* = object
   joined*: bool
   identicon*: string
   userName*: string
+  localNickname*: string
 
 proc toJsonNode*(self: ChatMember): JsonNode =
   result = %* {

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -32,23 +32,31 @@ proc blockContact*(self: ContactModel, id: string): string =
 proc unblockContact*(self: ContactModel, id: string): string =
   var contact = self.getContactByID(id)
   contact.systemTags.delete(contact.systemTags.find(":contact/blocked"))
-  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.systemTags)
+  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries,contact.alias, contact.identicon, contact.systemTags, contact.localNickname)
   self.events.emit("contactUnblocked", Args())
 
 proc getContacts*(self: ContactModel): seq[Profile] =
   result = map(status_contacts.getContacts().getElems(), proc(x: JsonNode): Profile = x.toProfileModel())
   self.events.emit("contactUpdate", ContactUpdateArgs(contacts: result))
 
-proc addContact*(self: ContactModel, id: string): string =
+proc addContact*(self: ContactModel, id: string, localNickname: string): string =
   let contact = self.getContactByID(id)
   contact.systemTags.add(":contact/added")
-  result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.systemTags)
+  let nickname =
+    if (localNickname == ""):
+      contact.localNickname
+    else:
+      localNickname
+  result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.systemTags, nickname)
   self.events.emit("contactAdded", Args())
+
+proc addContact*(self: ContactModel, id: string): string =
+  result = self.addContact(id)
 
 proc removeContact*(self: ContactModel, id: string) =
   let contact = self.getContactByID(id)
   contact.systemTags.delete(contact.systemTags.find(":contact/added"))
-  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.systemTags)
+  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.systemTags, contact.localNickname)
   self.events.emit("contactRemoved", Args())
 
 proc isAdded*(self: ContactModel, id: string): bool =

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -51,7 +51,7 @@ proc addContact*(self: ContactModel, id: string, localNickname: string): string 
   self.events.emit("contactAdded", Args())
 
 proc addContact*(self: ContactModel, id: string): string =
-  result = self.addContact(id)
+  result = self.addContact(id, "")
 
 proc removeContact*(self: ContactModel, id: string) =
   let contact = self.getContactByID(id)

--- a/src/status/ens.nim
+++ b/src/status/ens.nim
@@ -37,6 +37,8 @@ proc addDomain*(username: string): string =
 proc userNameOrAlias*(contact: Profile, removeSuffix: bool = false): string =
   if(contact.ensName != "" and contact.ensVerified):
     result = "@" & userName(contact.ensName, removeSuffix)
+  elif(contact.localNickname != ""):
+    result = contact.localNickname
   else:
     result = contact.alias
 

--- a/src/status/libstatus/contacts.nim
+++ b/src/status/libstatus/contacts.nim
@@ -26,7 +26,7 @@ proc getContacts*(): JsonNode =
     return %* []
   return response["result"]
 
-proc saveContact*(id: string, ensVerified: bool, ensName: string, ensVerifiedAt: int, ensVerificationRetries: int, alias: string, identicon: string, systemTags: seq[string]): string =
+proc saveContact*(id: string, ensVerified: bool, ensName: string, ensVerifiedAt: int, ensVerificationRetries: int, alias: string, identicon: string, systemTags: seq[string], localNickname: string): string =
   let payload = %* [{
       "id": id,
       "name": ensName,
@@ -35,6 +35,7 @@ proc saveContact*(id: string, ensVerified: bool, ensName: string, ensVerifiedAt:
       "ensVerificationRetries": ensVerificationRetries,
       "alias": alias,
       "identicon": identicon,
-      "systemTags": systemTags
+      "systemTags": systemTags,
+      "localNickname": localNickname
     }]
   callPrivateRPC("saveContact".prefix, payload)

--- a/src/status/profile/profile.nim
+++ b/src/status/profile/profile.nim
@@ -2,7 +2,7 @@ import json
 import ../libstatus/types
 
 type Profile* = ref object
-  id*, alias*, username*, identicon*, address*, ensName*: string
+  id*, alias*, username*, identicon*, address*, ensName*, localNickname*: string
   ensVerified*: bool
   ensVerifiedAt*, ensVerificationRetries*, appearance*: int
   systemTags*: seq[string]
@@ -48,3 +48,6 @@ proc toProfileModel*(profile: JsonNode): Profile =
   
   if profile.hasKey("name"):
     result.ensName = profile["name"].str
+  
+  if profile.hasKey("localNickname"):
+    result.localNickname = profile["localNickname"].str

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -140,7 +140,7 @@ StackLayout {
         BlockContactConfirmationDialog {
             id: blockContactConfirmationDialog
             onBlockButtonClicked: {
-                chatsModel.blockContact(blockContactConfirmationDialog.contactAddress)
+                profileModel.blockContact(blockContactConfirmationDialog.contactAddress)
                 blockContactConfirmationDialog.close()
                 profilePopup.close()
             }

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -65,7 +65,18 @@ Item {
         if (!isProfileClick) {
             SelectedMessage.set(messageId, fromAuthor);
         }
-        profileClick(userName, fromAuthor, identicon);
+        // Get contact nickname
+        const contactList = profileModel.contactList
+        const contactCount = contactList.rowCount()
+        let nickname = ""
+        for (let i = 0; i < contactCount; i++) {
+            if (contactList.rowData(i, 'pubKey') === fromAuthor) {
+                nickname = contactList.rowData(i, 'localNickname')
+                break;
+            }
+        }
+
+        profileClick(userName, fromAuthor, identicon, "", nickname);
         messageContextMenu.isProfile = !!isProfileClick
         messageContextMenu.isSticker = isSticker
         messageContextMenu.popup()

--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -28,9 +28,11 @@ ModalPopup {
         }
 
         data.clear();
-        for(let i = 0; i < profileModel.contactList.rowCount(); i++){
+        const nbContacts = profileModel.contactList.rowCount()
+        for(let i = 0; i < nbContacts; i++){
             data.append({
                 name: profileModel.contactList.rowData(i, "name"),
+                localNickname: profileModel.contactList.rowData(i, "localNickname"),
                 pubKey: profileModel.contactList.rowData(i, "pubKey"),
                 address: profileModel.contactList.rowData(i, "address"),
                 identicon: profileModel.contactList.rowData(i, "identicon"),
@@ -163,13 +165,14 @@ ModalPopup {
                 pubKey: model.pubKey
                 isContact: model.isContact
                 isUser: model.isUser
-                name: model.name
+                name: !model.name.endsWith(".eth") && !!model.localNickname ?
+                          model.localNickname : Utils.removeStatusEns(model.name)
                 address: model.address
                 identicon: model.identicon
                 onItemChecked: function(pubKey, itemChecked){
                     var idx = pubKeys.indexOf(pubKey)
                     if(itemChecked){
-                        if(idx == -1){
+                        if(idx === -1){
                             pubKeys.push(pubKey)
                         }
                     } else {

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -21,7 +21,7 @@ ModalPopup {
         data.clear();
         for(let i = 0; i < profileModel.contactList.rowCount(); i++){
             if(chatsModel.activeChannel.contains(profileModel.contactList.rowData(i, "pubKey"))) continue;
-            if(profileModel.contactList.rowData(i, "isContact") == "false") continue;
+            if(profileModel.contactList.rowData(i, "isContact") === "false") continue;
             data.append({
                 name: profileModel.contactList.rowData(i, "name"),
                 pubKey: profileModel.contactList.rowData(i, "pubKey"),
@@ -309,12 +309,22 @@ ModalPopup {
                         Layout.fillWidth: true
                         font.pixelSize: 13
                         MouseArea {
-                          anchors.fill: parent
-                          cursorShape: Qt.PointingHandCursor
-                          onClicked: {
-                            popup.profileClick(model.userName, model.pubKey, model.identicon)
-                            popup.close()
-                          }
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                // Get contact nickname
+                                const contactList = profileModel.contactList
+                                const contactCount = contactList.rowCount()
+                                let nickname = ""
+                                for (let i = 0; i < contactCount; i++) {
+                                    if (contactList.rowData(i, 'pubKey') === model.pubKey) {
+                                        nickname = contactList.rowData(i, 'localNickname')
+                                        break;
+                                    }
+                                }
+                                popup.profileClick(model.userName, model.pubKey, model.identicon, '', nickname)
+                                popup.close()
+                            }
                         }
                     }
 

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -278,6 +278,7 @@ ModalPopup {
                             return contactList.rowData(i, 'localNickname')
                         }
                     }
+                    return ""
                 }
 
                 Column {

--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -83,6 +83,7 @@ PopupMenu {
             }
             onClicked: {
                 profilePopup.open()
+                messageContextMenu.close()
             }
         }
     }
@@ -95,7 +96,10 @@ PopupMenu {
         id: viewProfileAction
         //% "View profile"
         text: qsTrId("view-profile")
-        onTriggered: profilePopup.open()
+        onTriggered: {
+            profilePopup.open()
+            messageContextMenu.close()
+        }
         icon.source: "../../../img/profileActive.svg"
         icon.width: 16
         icon.height: 16
@@ -106,7 +110,10 @@ PopupMenu {
                   qsTrId("send-message") :
                   //% "Reply to"
                   qsTrId("reply-to")
-        onTriggered: messageContextMenu.isProfile ? chatsModel.joinChat(profilePopup.fromAuthor, Constants.chatTypeOneToOne) : showReplyArea()
+        onTriggered: {
+            messageContextMenu.isProfile ? chatsModel.joinChat(profilePopup.fromAuthor, Constants.chatTypeOneToOne) : showReplyArea()
+            messageContextMenu.close()
+        }
         icon.source: "../../../img/messageActive.svg"
         icon.width: 16
         icon.height: 16

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -1,0 +1,81 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.13
+import "../../../../imports"
+import "../../../../shared"
+import "./"
+
+ModalPopup {
+    property int nicknameLength: nicknameInput.textField.text.length
+    readonly property int maxNicknameLength: 32
+    property bool nicknameTooLong: nicknameLength > maxNicknameLength
+
+    id: popup
+
+    header: Item {
+        height: childrenRect.height
+        width: parent.width
+
+        StyledText {
+            id: nicknameTitle
+            text:  qsTr("Nickname")
+            anchors.top: parent.top
+            anchors.topMargin: 18
+            anchors.left: parent.left
+            anchors.leftMargin: Style.current.smallPadding
+            font.bold: true
+            font.pixelSize: 14
+        }
+
+        StyledText {
+            text: isEnsVerified ? alias : fromAuthor
+            width: 160
+            elide: !isEnsVerified ? Text.ElideMiddle : Text.ElideNone
+            anchors.left: nicknameTitle.left
+            anchors.top: nicknameTitle.bottom
+            anchors.topMargin: 2
+            font.pixelSize: 14
+            color: Style.current.secondaryText
+        }
+    }
+
+    StyledText {
+        id: descriptionText
+        text: qsTr("Nicknames help you identify others in Status. Only you can see the nicknames you’ve added")
+        font.pixelSize: 15
+        wrapMode: Text.WordWrap
+        color: Style.current.secondaryText
+        width: parent.width
+    }
+
+    Input {
+        id: nicknameInput
+        placeholderText: qsTr("Nickname")
+        anchors.top: descriptionText.bottom
+        anchors.topMargin: Style.current.padding
+        validationError: popup.nicknameTooLong ? qsTr("Your nickname is too long") : ""
+    }
+
+    StyledText {
+        id: lengthLimitText
+        text: popup.nicknameLength + "/" + popup.maxNicknameLength
+        font.pixelSize: 15
+        anchors.top: nicknameInput.bottom
+        anchors.topMargin: 12
+        anchors.right: parent.right
+        color: popup.nicknameTooLong ? Style.current.danger : Style.current.secondaryText
+    }
+
+    footer: StyledButton {
+        id: doneBtn
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.smallPadding
+        label: qsTr("Done")
+        anchors.bottom: parent.bottom
+        disabled: popup.nicknameLength === 0 || popup.nicknameTooLong
+        onClicked: {
+            console.log('Nickname set')
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -52,6 +52,7 @@ ModalPopup {
     Input {
         id: nicknameInput
         placeholderText: qsTr("Nickname")
+        text: nickname
         anchors.top: descriptionText.bottom
         anchors.topMargin: Style.current.padding
         validationError: popup.nicknameTooLong ? qsTr("Your nickname is too long") : ""
@@ -75,7 +76,9 @@ ModalPopup {
         anchors.bottom: parent.bottom
         disabled: popup.nicknameLength === 0 || popup.nicknameTooLong
         onClicked: {
-            console.log('Nickname set')
+            userName = nicknameInput.textField.text
+            profileModel.changeContactNickname(fromAuthor, nicknameInput.textField.text)
+            popup.close()
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -78,6 +78,7 @@ ModalPopup {
         disabled: popup.nicknameLength === 0 || popup.nicknameTooLong
         onClicked: {
             userName = nicknameInput.textField.text
+            nickname = nicknameInput.textField.text
             profileModel.changeContactNickname(fromAuthor, nicknameInput.textField.text)
             popup.close()
         }

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -12,6 +12,7 @@ ModalPopup {
     property bool nicknameTooLong: nicknameLength > maxNicknameLength
 
     id: popup
+    height: 325
 
     header: Item {
         height: childrenRect.height

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -77,7 +77,10 @@ ModalPopup {
         anchors.bottom: parent.bottom
         disabled: popup.nicknameLength === 0 || popup.nicknameTooLong
         onClicked: {
-            userName = nicknameInput.textField.text
+            if (!userName.startsWith("@")) {
+                // Replace username only if it was not an ENS name
+                userName = nicknameInput.textField.text
+            }
             nickname = nicknameInput.textField.text
             profileModel.changeContactNickname(fromAuthor, nicknameInput.textField.text)
             popup.close()

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -8,12 +8,12 @@ import "./"
 
 ModalPopup {
     id: popup
-    property string identicon: ""
-    property string userName: ""
-    property string nickname: ""
-    property string fromAuthor: ""
-    property string text: ""
-    property string alias: ""
+    property var identicon: ""
+    property var userName: ""
+    property var nickname: ""
+    property var fromAuthor: ""
+    property var text: ""
+    property var alias: ""
     
     property bool showQR: false
     property bool isEnsVerified: false
@@ -32,9 +32,9 @@ ModalPopup {
         isEnsVerified = chatsModel.isEnsVerified(this.fromAuthor)
         alias = chatsModel.alias(this.fromAuthor) || ""
     }
-    
+
     function openPopup(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam) {
-        setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam);
+        setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam)
         popup.open()
     }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -294,7 +294,15 @@ ModalPopup {
             anchors.top: nicknameTitle.top
             anchors.bottom: nicknameTitle.bottom
             onClicked: {
-                console.log('Go to nickname modal')
+                nicknamePopup.open()
+                popup.close()
+            }
+        }
+
+        NicknamePopup {
+            id: nicknamePopup
+            onClosed: {
+                popup.open()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.13
 import "../../../../imports"
 import "../../../../shared"
 import "./"
@@ -78,7 +79,7 @@ ModalPopup {
             anchors.top: profileName.bottom
             anchors.topMargin: 2
             font.pixelSize: 14
-            color: Style.current.darkGrey
+            color: Style.current.secondaryText
         }
 
         Rectangle {
@@ -134,6 +135,7 @@ ModalPopup {
 
     Item {
         anchors.fill: parent
+        anchors.leftMargin: Style.current.smallPadding
         visible: !showQR
 
         StyledText {
@@ -144,9 +146,7 @@ ModalPopup {
             text: qsTrId("ens-username")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
+            color: Style.current.secondaryText
             anchors.top: parent.top
             anchors.topMargin: Style.current.smallPadding
         }
@@ -157,8 +157,6 @@ ModalPopup {
             height: isEnsVerified ? 20 : 0
             text: userName.substr(1)
             font.pixelSize: 14
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelEnsUsername.bottom
             anchors.topMargin: Style.current.smallPadding
         }
@@ -168,7 +166,6 @@ ModalPopup {
             height: isEnsVerified ? 20 : 0
             anchors.top: labelEnsUsername.bottom
             anchors.left: valueEnsName.right
-            anchors.leftMargin: Style.current.smallPadding
             textToCopy: valueEnsName.text
         }
 
@@ -178,9 +175,7 @@ ModalPopup {
             text: qsTrId("chat-key")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
+            color: Style.current.secondaryText
             anchors.top: isEnsVerified ? valueEnsName.bottom : parent.top
             anchors.topMargin: Style.current.padding
         }
@@ -192,8 +187,6 @@ ModalPopup {
             maxWidth: parent.width - (3 * Style.current.smallPadding) - copyBtn.width
             color: Style.current.textColor
             font.pixelSize: 14
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelChatKey.bottom
             anchors.topMargin: Style.current.smallPadding
         }
@@ -202,7 +195,6 @@ ModalPopup {
             id: copyBtn
             anchors.top: labelChatKey.bottom
             anchors.left: valueChatKey.right
-            anchors.leftMargin: Style.current.smallPadding
             textToCopy: valueChatKey.text
         }
 
@@ -222,9 +214,7 @@ ModalPopup {
             text: qsTrId("share-profile-url")
             font.pixelSize: 13
             font.weight: Font.Medium
-            color: Style.current.darkGrey
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
+            color: Style.current.secondaryText
             anchors.top: separator.bottom
             anchors.topMargin: Style.current.padding
         }
@@ -234,8 +224,6 @@ ModalPopup {
             text: "https://join.status.im/u/" + fromAuthor.substr(
                       0, 4) + "..." + fromAuthor.substr(fromAuthor.length - 5)
             font.pixelSize: 14
-            anchors.left: parent.left
-            anchors.leftMargin: Style.current.smallPadding
             anchors.top: labelShareURL.bottom
             anchors.topMargin: Style.current.smallPadding
         }
@@ -243,8 +231,71 @@ ModalPopup {
         CopyToClipBoardButton {
             anchors.top: labelShareURL.bottom
             anchors.left: valueShareURL.right
-            anchors.leftMargin: Style.current.smallPadding
             textToCopy: "https://join.status.im/u/" + fromAuthor
+        }
+
+        Separator {
+            id: separator2
+            anchors.top: valueShareURL.bottom
+            anchors.topMargin: Style.current.padding
+            anchors.left: parent.left
+            anchors.leftMargin: -Style.current.padding
+            anchors.right: parent.right
+            anchors.rightMargin: -Style.current.padding
+        }
+
+        StyledText {
+            id: chatSettings
+            text: qsTr("Chat settings")
+            font.pixelSize: 13
+            font.weight: Font.Medium
+            color: Style.current.secondaryText
+            anchors.top: separator2.bottom
+            anchors.topMargin: Style.current.padding
+        }
+
+        StyledText {
+            id: nicknameTitle
+            text: qsTr("Nickname")
+            font.pixelSize: 14
+            anchors.top: chatSettings.bottom
+            anchors.topMargin: Style.current.smallPadding
+        }
+
+        SVGImage {
+            id: nicknameCaret
+            source: "../../../img/caret.svg"
+            rotation: -90
+            anchors.right: parent.right
+            anchors.rightMargin: Style.current.padding
+            anchors.verticalCenter: nicknameTitle.verticalCenter
+            width: 13
+            fillMode: Image.PreserveAspectFit
+            ColorOverlay {
+                anchors.fill: parent
+                source: parent
+                color: Style.current.secondaryText
+            }
+        }
+
+        StyledText {
+            id: nickname
+            text: qsTr("None")
+            anchors.right: nicknameCaret.left
+            anchors.rightMargin: Style.current.padding
+            anchors.verticalCenter: nicknameTitle.verticalCenter
+            color: Style.current.secondaryText
+        }
+
+        MouseArea {
+            cursorShape: Qt.PointingHandCursor
+            anchors.left: nicknameTitle.left
+            anchors.right: nicknameCaret.right
+            anchors.top: nicknameTitle.top
+            anchors.bottom: nicknameTitle.bottom
+            onClicked: {
+                console.log('Go to nickname modal')
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -22,10 +22,10 @@ ModalPopup {
     signal blockButtonClicked(name: string, address: string)
     signal removeButtonClicked(address: string)
 
-    function setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam){
+    function setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam) {
         showQR = false
         userName = userNameParam || ""
-        nickname = userName.startsWith("@") ? "" : userName
+        nickname = nicknameParam || ""
         fromAuthor = fromAuthorParam || ""
         identicon = identiconParam || ""
         text = textParam || ""
@@ -33,8 +33,8 @@ ModalPopup {
         alias = chatsModel.alias(this.fromAuthor) || ""
     }
     
-    function openPopup(userNameParam, fromAuthorParam, identiconParam) {
-        setPopupData(userNameParam, fromAuthorParam, identiconParam, "");
+    function openPopup(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam) {
+        setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam);
         popup.open()
     }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -8,11 +8,12 @@ import "./"
 
 ModalPopup {
     id: popup
-    property var identicon: ""
-    property var userName: ""
-    property var fromAuthor: ""
-    property var text: ""
-    property var alias: ""
+    property string identicon: ""
+    property string userName: ""
+    property string nickname: ""
+    property string fromAuthor: ""
+    property string text: ""
+    property string alias: ""
     
     property bool showQR: false
     property bool isEnsVerified: false
@@ -22,13 +23,14 @@ ModalPopup {
     signal removeButtonClicked(address: string)
 
     function setPopupData(userNameParam, fromAuthorParam, identiconParam, textParam){
-        this.showQR = false
-        this.userName = userNameParam
-        this.fromAuthor = fromAuthorParam
-        this.identicon = identiconParam
-        this.text = textParam
-        this.isEnsVerified = chatsModel.isEnsVerified(this.fromAuthor)
-        this.alias = chatsModel.alias(this.fromAuthor)
+        showQR = false
+        userName = userNameParam || ""
+        nickname = userName.startsWith("@") ? "" : userName
+        fromAuthor = fromAuthorParam || ""
+        identicon = identiconParam || ""
+        text = textParam || ""
+        isEnsVerified = chatsModel.isEnsVerified(this.fromAuthor)
+        alias = chatsModel.alias(this.fromAuthor) || ""
     }
     
     function openPopup(userNameParam, fromAuthorParam, identiconParam) {
@@ -279,8 +281,8 @@ ModalPopup {
         }
 
         StyledText {
-            id: nickname
-            text: qsTr("None")
+            id: nicknameText
+            text: nickname ? nickname : qsTr("None")
             anchors.right: nicknameCaret.left
             anchors.rightMargin: Style.current.padding
             anchors.verticalCenter: nicknameTitle.verticalCenter

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -356,7 +356,7 @@ ModalPopup {
                 if (profileModel.isAdded(fromAuthor)) {
                     popup.removeButtonClicked(fromAuthor)
                 } else {
-                    chatsModel.addContact(fromAuthor)
+                    profileModel.addContact(fromAuthor)
                 }
                 profilePopup.close()
             }

--- a/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Contacts/Contact.qml
@@ -9,6 +9,7 @@ Rectangle {
     property string name: "Jotaro Kujo"
     property string address: "0x04d8c07dd137bd1b73a6f51df148b4f77ddaa11209d36e43d8344c0a7d6db1cad6085f27cfb75dd3ae21d86ceffebe4cf8a35b9ce8d26baa19dc264efe6d8f221b"
     property string identicon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    property string localNickname: "JoJo"
     property bool selectable: false
     property var profileClick: function() {}
     property bool isContact: true
@@ -92,7 +93,7 @@ Rectangle {
                     icon.width: menuButton.iconSize
                     icon.height: menuButton.iconSize
                     text: qsTrId("view-profile")
-                    onTriggered: profileClick(name, address, identicon)
+                    onTriggered: profileClick(name, address, identicon, "", localNickname)
                     enabled: true
                 }
                 Action {

--- a/ui/app/AppLayouts/Profile/Sections/Contacts/ContactList.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Contacts/ContactList.qml
@@ -23,6 +23,7 @@ ListView {
     delegate: Contact {
         name: Utils.removeStatusEns(model.name)
         address: model.address
+        localNickname: model.localNickname
         identicon: model.identicon
         isContact: model.isContact
         isBlocked: model.isBlocked

--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -202,7 +202,6 @@ Item {
         footer: StyledButton {
             anchors.right: parent.right
             anchors.leftMargin: Style.current.padding
-            //% "Send Message"
             //% "Add contact"
             label: qsTrId("add-contact")
             disabled: !contactToAddInfo.visible

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -152,6 +152,7 @@ DISTFILES += \
     app/AppLayouts/Chat/components/EmojiCategoryButton.qml \
     app/AppLayouts/Chat/components/EmojiPopup.qml \
     app/AppLayouts/Chat/components/EmojiReaction.qml \
+    app/AppLayouts/Chat/components/ProfilePopup.qml \
     app/AppLayouts/Chat/components/EmojiSection.qml \
     app/AppLayouts/Chat/components/InviteFriendsPopup.qml \
     app/AppLayouts/Chat/components/MessageContextMenu.qml \

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -155,6 +155,7 @@ DISTFILES += \
     app/AppLayouts/Chat/components/EmojiSection.qml \
     app/AppLayouts/Chat/components/InviteFriendsPopup.qml \
     app/AppLayouts/Chat/components/MessageContextMenu.qml \
+    app/AppLayouts/Chat/components/NicknamePopup.qml \
     app/AppLayouts/Profile/LeftTab/Constants.js \
     app/AppLayouts/Profile/LeftTab/components/MenuButton.qml \
     app/AppLayouts/Chat/data/EmojiReactions.qml \


### PR DESCRIPTION
Fixes #833 

Adds a nickname popup to set the nickname of a contact. It is then saved in the Contact itslef in Sttaus-Go.

I also refactored quickly chatModel because it had `addContact`, `blockContact`, etc. and profileModel had it too. So I made the decision to only keep the profileModel ones.

![image](https://user-images.githubusercontent.com/11926403/93485988-ac40c280-f8d1-11ea-99e6-397e9250f8e9.png)

![image](https://user-images.githubusercontent.com/11926403/93486013-b498fd80-f8d1-11ea-8e89-c95bc681681c.png)

![image](https://user-images.githubusercontent.com/11926403/93486064-c1b5ec80-f8d1-11ea-9c06-45f0abe88f3d.png)

