### PR TITLE
feat: add sticker loading UI

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -37,7 +37,6 @@ proc init*(self: ChatController) =
   self.status.mailservers.init()
   self.status.chat.init()
   self.status.stickers.init()
-  self.view.obtainAvailableStickerPacks()
   let pubKey = status_settings.getSetting[string](Setting.PublicKey, "0x0")
   self.view.pubKey = pubKey
 
@@ -45,3 +44,4 @@ proc init*(self: ChatController) =
   for sticker in recentStickers:
     self.view.addRecentStickerToList(sticker)
     self.status.stickers.addStickerToRecent(sticker)
+  self.view.obtainAvailableStickerPacks()

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -133,6 +133,12 @@ QtObject:
         packs.add(stickerPack)
       $(%*(packs))
 
+  proc stickerPacksLoaded*(self: ChatsView) {.signal.}
+
+  proc installedStickerPacksUpdated*(self: ChatsView) {.signal.}
+
+  proc recentStickersUpdated*(self: ChatsView) {.signal.}
+
   proc setAvailableStickerPacks*(self: ChatsView, availableStickersJSON: string) {.slot.} =
     let
       accounts = status_wallet.getWalletAccounts() # TODO: make generic
@@ -156,6 +162,8 @@ QtObject:
       let isPending = pendingStickerPacks.contains(stickerPack.id) and not isBought
       self.status.stickers.availableStickerPacks[stickerPack.id] = stickerPack
       self.addStickerPackToList(stickerPack, isInstalled, isBought, isPending)
+    self.stickerPacksLoaded()
+    self.installedStickerPacksUpdated()
 
   proc getChatsList(self: ChatsView): QVariant {.slot.} =
     newQVariant(self.chats)
@@ -260,9 +268,17 @@ QtObject:
     write = setActiveChannelByIndex
     notify = activeChannelChanged
 
+  proc getNumInstalledStickerPacks(self: ChatsView): QVariant {.slot.} =
+    newQVariant(self.status.stickers.installedStickerPacks.len)
+
+  QtProperty[QVariant] numInstalledStickerPacks:
+    read = getNumInstalledStickerPacks
+    notify = installedStickerPacksUpdated
+
   proc installStickerPack*(self: ChatsView, packId: int) {.slot.} =
     self.status.stickers.installStickerPack(packId)
     self.stickerPacks.updateStickerPackInList(packId, true, false)
+    self.installedStickerPacksUpdated()
 
   proc resetStickerPackBuyAttempt*(self: ChatsView, packId: int) {.slot.} =
     self.stickerPacks.updateStickerPackInList(packId, false, false)
@@ -272,12 +288,15 @@ QtObject:
     self.status.stickers.removeRecentStickers(packId)
     self.stickerPacks.updateStickerPackInList(packId, false, false)
     self.recentStickers.removeStickersFromList(packId)
+    self.installedStickerPacksUpdated()
+    self.recentStickersUpdated()
 
   proc getRecentStickerList*(self: ChatsView): QVariant {.slot.} =
     result = newQVariant(self.recentStickers)
 
   QtProperty[QVariant] recentStickers:
     read = getRecentStickerList
+    notify = recentStickersUpdated
 
   proc setActiveChannel*(self: ChatsView, channel: string) {.slot.} =
     if(channel == ""): return
@@ -398,6 +417,7 @@ QtObject:
 
   proc addRecentStickerToList*(self: ChatsView, sticker: Sticker) =
     self.recentStickers.addStickerToList(sticker)
+    self.recentStickersUpdated()
   
   proc copyToClipboard*(self: ChatsView, content: string) {.slot.} =
     setClipBoardText(content)


### PR DESCRIPTION
Closes: #586

<img src="https://imgur.com/3wUKPVC.png" width="400">

Previously, loading sticker packs and stickers would show a lot of blank and non-interactive content.

Now, stickers and sticker packs have grey circles to indicate loading. Additionally, the sticker market button (+) shows a loading indicator until the sticker packs are loaded.

### Note
If a recent sticker is clicked while the sticker packs are still loading, the app crashes due to some kind of conflict in threads. I spent some time trying to figure this out, but could not get anywhere. Maybe @richard-ramos has an idea?