### PR TITLE
fix: fix spaces and line breaks disappearing when pasting

### DIFF
--- a/ui/app/AppLayouts/Chat/components/EmojiPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/EmojiPopup.qml
@@ -64,7 +64,7 @@ Popup {
         emojiSectionsRepeater.itemAt(0).allEmojis = recentEmojis
         appSettings.recentEmojis = recentEmojis
 
-        popup.addToChat(Emoji.parse(encodedIcon, "26x26") + ' ') // Adding a space because otherwise, some emojis would fuse since it's just an emoji is just a string
+        popup.addToChat(Emoji.parse(encodedIcon, "26x26") + ' ', true) // Adding a space because otherwise, some emojis would fuse since it's just an emoji is just a string
         popup.close()
         chatInput.textInput.forceActiveFocus()
     }

--- a/ui/app/AppLayouts/Chat/components/EmojiPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/EmojiPopup.qml
@@ -64,7 +64,7 @@ Popup {
         emojiSectionsRepeater.itemAt(0).allEmojis = recentEmojis
         appSettings.recentEmojis = recentEmojis
 
-        popup.addToChat(Emoji.parse(encodedIcon, "26x26") + ' ', true) // Adding a space because otherwise, some emojis would fuse since it's just an emoji is just a string
+        popup.addToChat(Emoji.parse(encodedIcon, "26x26") + ' ', true) // Adding a space because otherwise, some emojis would fuse since emoji is just a string
         popup.close()
         chatInput.textInput.forceActiveFocus()
     }


### PR DESCRIPTION
Fixes #967

Also now enables using the emoji selector (popup) in between words instead of always putting the emoji at the end