### PR TITLE
feat: enable loading all the cryptokitties assets with recursion

### DIFF
--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -95,7 +95,7 @@ proc getCryptoKittiesBatch*(address: Address, offset: int = 0): seq[Collectible]
   let total = responseBody["total"].getInt
   let currentCount = limit * (offset + 1)
   if (currentCount < total and currentCount < MAX_TOKENS):
-    # Call the API again with oofset + 1
+    # Call the API again with offset + 1
     let nextBatch = getCryptoKittiesBatch(address, offset + 1)
     return concat(cryptokitties, nextBatch)
   return cryptokitties

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -78,16 +78,16 @@ proc getCryptoKittiesBatch*(address: Address, offset: int = 0): seq[Collectible]
       var name = kitty["name"]
       var finalId = ""
       var finalName = ""
-      if (not (id.kind == JNull)):
+      if id.kind != JNull:
         finalId = $id
-      if (not (name.kind == JNull)):
+      if name.kind != JNull:
         finalName = $name
       cryptokitties.add(Collectible(id: finalId,
-      name: finalName,
-      image: kitty["image_url_png"].str,
-      collectibleType: CRYPTOKITTY,
-      description: "",
-      externalUrl: ""))
+        name: finalName,
+        image: kitty["image_url_png"].str,
+        collectibleType: CRYPTOKITTY,
+        description: "",
+        externalUrl: ""))
     except Exception as e2:
       error "Error with this individual cat", msg = e2.msg, cat = kitty
 

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -14,6 +14,8 @@ const STICKER* = "stickers"
 
 const COLLECTIBLE_TYPES* = [CRYPTOKITTY, KUDO, ETHERMON, STICKER]
 
+const MAX_TOKENS = 200
+
 proc getTokenUri(contract: Contract, tokenId: Stuint[256]): string =
   try:
     let
@@ -54,7 +56,7 @@ proc tokensOfOwnerByIndex(contract: Contract, address: Address): seq[int] =
   result = @[]
   while (true):
     token = tokenOfOwnerByIndex(contract, address, index.u256)
-    if (token == -1 or token == 0):
+    if (token == -1 or token == 0 or result.len > MAX_TOKENS):
       return result
     result.add(token)
     index = index + 1
@@ -91,7 +93,8 @@ proc getCryptoKittiesBatch*(address: Address, offset: int = 0): seq[Collectible]
 
   let limit = responseBody["limit"].getInt
   let total = responseBody["total"].getInt
-  if (limit * (offset + 1) < total):
+  let currentCount = limit * (offset + 1)
+  if (currentCount < total and currentCount < MAX_TOKENS):
     # Call the API again with oofset + 1
     let nextBatch = getCryptoKittiesBatch(address, offset + 1)
     return concat(cryptokitties, nextBatch)

--- a/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesHeader.qml
+++ b/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesHeader.qml
@@ -29,10 +29,23 @@ Rectangle {
     }
 
     StyledText {
+        id: collectibleName
         text: collectibleHeader.collectibleName
         anchors.left: collectibleIconImage.right
         anchors.leftMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
+        font.pixelSize: 17
+    }
+
+    StyledText {
+        visible: collectiblesQty >= Constants.maxTokens
+        text: qsTr("Maximum number of collectibles to display reached")
+        font.pixelSize: 17
+        color: Style.current.secondaryText
+        anchors.left: collectibleName.right
+        anchors.leftMargin: Style.current.padding
+        anchors.verticalCenter: parent.verticalCenter
+
     }
 
     Loader {

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -36,6 +36,8 @@ QtObject {
     readonly property int pending: 6
     readonly property int confirmed: 7
 
+    readonly property int maxTokens: 200
+
     readonly property string zeroAddress: "0x0000000000000000000000000000000000000000"
 
     readonly property var accountColors: [


### PR DESCRIPTION
Fixes #807 
Before, we only loaded 20 because that is the Cryptokitties API limit.
Now, we load everything using a recursive function and increasing the offset