### PR TITLE
feat: introduce a character limit with a char limit counter UI

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -206,7 +206,7 @@ StackLayout {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
             Layout.fillWidth: true
             Layout.preferredWidth: parent.width
-            height: !isExtendedInput ? 70 : 140
+            height: (!isExtendedInput ? 70 : 140) * chatInput.extraHeightFactor
             Layout.preferredHeight: height
 
             SuggestionBox {


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-status-client/issues/1006

The chat input bar height adjusts to the message length (The height attributes supports integer so the transition isn't as smooth). The color of the message size changes from green to red if user has passed the character limit. The message won't be send if limit is passed, but instead a MessageModal will open explaining that to be courteous you need to adhere to 2000 char limit.

![](https://i.imgur.com/uvASeCQ.png)
![](https://i.imgur.com/apAI98Y.png)
![](https://i.imgur.com/YOnJyHG.png)