### PR TITLE
fix: Estimating gas prevents transaction modal continue

### DIFF
--- a/src/app/utilsView/view.nim
+++ b/src/app/utilsView/view.nim
@@ -48,10 +48,10 @@ QtObject:
   proc wei2Token*(self: UtilsView, wei: string, decimals: int): string {.slot.} =
     return status_utils.wei2Token(wei, decimals)
 
-  proc getStickerMarketAddress(self: UtilsView): QVariant {.slot.} =
-    newQVariant($self.status.stickers.getStickerMarketAddress)
+  proc getStickerMarketAddress(self: UtilsView): string {.slot.} =
+    $self.status.stickers.getStickerMarketAddress
 
-  QtProperty[QVariant] stickerMarketAddress:
+  QtProperty[string] stickerMarketAddress:
     read = getStickerMarketAddress
 
   proc getEnsRegisterAddress(self: UtilsView): QVariant {.slot.} =

--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -457,10 +457,10 @@ QtObject:
 
   proc getGasPricePredictions*(self: WalletView) {.slot.} =
     let prediction = self.status.wallet.getGasPricePredictions()
-    self.safeLowGasPrice = prediction.safeLow
-    self.standardGasPrice = prediction.standard
-    self.fastGasPrice = prediction.fast
-    self.fastestGasPrice = prediction.fastest
+    self.safeLowGasPrice = $prediction.safeLow
+    self.standardGasPrice = $prediction.standard
+    self.fastGasPrice = $prediction.fast
+    self.fastestGasPrice = $prediction.fastest
     self.gasPricePredictionsChanged()
 
   proc safeLowGasPrice*(self: WalletView): string {.slot.} = result = ?.self.safeLowGasPrice

--- a/src/status/libstatus/types.nim
+++ b/src/status/libstatus/types.nim
@@ -25,10 +25,10 @@ proc event*(self:SignalType):string =
   result = "signal:" & $self
 
 type GasPricePrediction* = object
-  safeLow*: string
-  standard*: string
-  fast*: string
-  fastest*: string
+  safeLow*: float
+  standard*: float
+  fast*: float
+  fastest*: float
 
 type DerivedAccount* = object
   publicKey*: string

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -316,7 +316,7 @@ proc validateMnemonic*(self: WalletModel, mnemonic: string): string =
 
 proc getGasPricePredictions*(self: WalletModel): GasPricePrediction =
   if status_settings.getCurrentNetwork() == Network.Testnet:
-    return GasPricePrediction(safeLow: "1.0", standard: "2.0", fast: "3.0", fastest: "4.0")
+    return GasPricePrediction(safeLow: 1.0, standard: 2.0, fast: 3.0, fastest: 4.0)
   try:
     let url: string = fmt"https://etherchain.org/api/gasPriceOracle"
     let client = newHttpClient()

--- a/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
@@ -92,7 +92,7 @@ ModalPopup {
                 visible: false
                 accounts: walletModel.accounts
                 contacts: profileModel.addedContacts
-                selectedRecipient: { "address": chatsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
+                selectedRecipient: { "address": utilsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
                 onSelectedRecipientChanged: gasSelector.estimateGas()
             }

--- a/ui/shared/TransactionPreview.qml
+++ b/ui/shared/TransactionPreview.qml
@@ -75,7 +75,7 @@ Item {
                     when: !!root.toAccount && root.toAccount.type === RecipientSelector.Type.Address
                     PropertyChanges {
                         target: txtToPrimary
-                        text: root.toAccount ? root.toAccount.address || "" : ""
+                        text: root.toAccount ? root.toAccount.address : ""
                         elide: Text.ElideMiddle
                         anchors.leftMargin: 190
                         anchors.right: parent.right

--- a/ui/shared/status/StatusStickerPackPurchaseModal.qml
+++ b/ui/shared/status/StatusStickerPackPurchaseModal.qml
@@ -92,7 +92,7 @@ ModalPopup {
                 visible: false
                 accounts: walletModel.accounts
                 contacts: profileModel.addedContacts
-                selectedRecipient: { "address": chatsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
+                selectedRecipient: { "address": utilsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
                 onSelectedRecipientChanged: gasSelector.estimateGas()
             }


### PR DESCRIPTION
Fixes: #926.

Gas estimations were not being decoded correctly (indicated with "error getting gas price predictions" in the console) and were preventing transaction dialogs from continuing past the step containing the GasSelector component. This affected mainnet only, because in testnet we have hardcoded gas prices (for when the gas prices on mainnet are insane) which is why it was not apparent in testnet.

fix: Contract address not showing correctly
This was caused by `getStickerMarketContractAddress` being moved to `utilsView` but not updated in QML