### PR TITLE
feat: load more transactions with a button

### DIFF
--- a/src/app/wallet/views/transaction_list.nim
+++ b/src/app/wallet/views/transaction_list.nim
@@ -33,7 +33,10 @@ QtObject:
     result.transactions = @[]
     result.setup
 
-  method rowCount(self: TransactionList, index: QModelIndex = nil): int =
+  proc getLastTxBlockNumber*(self: TransactionList): string =
+    return self.transactions[^1].blockNumber
+
+  method rowCount*(self: TransactionList, index: QModelIndex = nil): int =
     return self.transactions.len
 
   method data(self: TransactionList, index: QModelIndex, role: int): QVariant =


### PR DESCRIPTION
fixes https://github.com/status-im/nim-status-client/issues/827

### Summary: 
A button is added that load mores transaction by appending newly fetched trxs to the current list.

### Caveats
I was unable to find a way to let the ListView + Scrollbar to start the display all the way to the bottom when new transactions are appended, so it always resets to the beginning of the list

###### Video demo
[https://i.imgur.com/xCzXZrK.mp4](https://i.imgur.com/xCzXZrK.mp4)
