### PR TITLE
ci: re-install Qt in Docker image to add QtWebEngine

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,12 +1,21 @@
 FROM a12e/docker-qt:5.14-gcc_64
 
+# $QT_PATH and $QT_PLATFORM are provided by the docker image
+# $QT_PATH/$QT_VERSION/$QT_PLATFORM/bin is already prepended to $PATH
+# However $QT_VERSION is not exposed to environment so set it here
+ENV QT_VERSION="5.14.0"
+ENV QTDIR="${QT_PATH}/${QT_VERSION}"
+ENV LD_LIBRARY_PATH="${QTDIR}/${QT_PLATFORM}/lib:${LD_LIBRARY_PATH}"
+# $OPENSSL_PREFIX is provided by the docker image
+ENV LIBRARY_PATH="${OPENSSL_PREFIX}/lib:${LIBRARY_PATH}"
+
 RUN export DEBIAN_FRONTEND=noninteractive \
  && sudo apt update -yq \
  && sudo apt install -yq software-properties-common \
  && sudo add-apt-repository -y ppa:git-core/ppa \
  && sudo apt update -yq \
  && sudo apt install -yq --fix-missing \
-        build-essential cmake git libpcre3-dev s3cmd
+      build-essential cmake git s3cmd libpcre3-dev libnss3 libxcomposite1 libxtst6
 
 # Installing Golang
 RUN GOLANG_SHA256="aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067" \
@@ -17,14 +26,12 @@ RUN GOLANG_SHA256="aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c
  && rm "${GOLANG_TARBALL}" \
  && sudo ln -s /usr/local/go/bin/go /usr/local/bin
 
-# $QT_PATH and $QT_PLATFORM are provided by the docker image
-# $QT_PATH/$QT_VERSION/$QT_PLATFORM/bin is already prepended to $PATH
-# However $QT_VERSION is not exposed to environment so set it here
-ENV QT_VERSION="5.14.0"
-ENV QTDIR="${QT_PATH}/${QT_VERSION}"
-ENV LD_LIBRARY_PATH="${QTDIR}/${QT_PLATFORM}/lib:${LD_LIBRARY_PATH}"
-# $OPENSSL_PREFIX is provided by the docker image
-ENV LIBRARY_PATH="${OPENSSL_PREFIX}/lib:${LIBRARY_PATH}"
+# Re-install Qt with QtWebEngine by adjusting QT_CI_PACKAGES
+# The http_proxy=invalid is a fix for getting stuck on 'Welcome Page'
+RUN sudo sed /tmp/build/install-qt.sh -i \
+      -e 's/^QT_CI_PACKAGES=.*/export QT_CI_PACKAGES=qt.qt5.5140.gcc_64,qt.qt5.5140.qtwebengine,qt.qt5/' \
+      -e '\#^/tmp/build/bin/extract-qt-installer.*#i export http_proxy=invalid' \
+ && sudo -E /tmp/build/install-qt.sh
 
 # Jenkins user needs a specific UID/GID to work
 RUN sudo groupadd -g 1001 jenkins \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -4,7 +4,7 @@ pipeline {
   agent {
     docker { 
       label 'linux'
-      image 'statusteam/nim-status-client-build:latest'
+      image 'statusteam/nim-status-client-build:1.0.0'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }


### PR DESCRIPTION
We do this here to avoid having to fork the original image repo: https://github.com/a12e/docker-qt

Resolves: https://github.com/status-im/nim-status-client/issues/523

I also switched from using `latest` tag to `1.0.0`. I wanted to use commit `SHA1` but that would change once this is merged...