### PR TITLE
fix: 1:1 chat command transactions "intrinsic gas too low"

### DIFF
--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -279,18 +279,18 @@ QtObject:
   proc transactionSent(self: WalletView, txResult: string) {.slot.} =
     self.transactionWasSent(txResult)
 
-  proc sendTransaction*(self: WalletView, from_addr: string, to: string, assetAddress: string, value: string, gas: string, gasPrice: string, password: string) {.slot.} =
+  proc sendTransaction*(self: WalletView, from_addr: string, to: string, assetAddress: string, value: string, gas: string, gasPrice: string, password: string, uuid: string) {.slot.} =
     let wallet = self.status.wallet
     if assetAddress != ZERO_ADDRESS and not assetAddress.isEmptyOrWhitespace:
       spawnAndSend(self, "transactionSent") do:
         var success: bool
         let response = wallet.sendTokenTransaction(from_addr, to, assetAddress, value, gas, gasPrice, password, success)
-        $(%* { "result": %response, "success": %success })
+        $(%* { "result": %response, "success": %success, "uuid": %uuid })
     else:
       spawnAndSend(self, "transactionSent") do:
         var success: bool
         let response = wallet.sendTransaction(from_addr, to, value, gas, gasPrice, password, success)
-        $(%* { "result": %response, "success": %success })
+        $(%* { "result": %response, "success": %success, "uuid": %uuid })
 
   proc getDefaultAccount*(self: WalletView): string {.slot.} =
     self.currentAccount.address

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
@@ -44,7 +44,7 @@ ModalPopup {
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "From account"
-                label: qsTrId("from-account")
+                label: root.isRequested ? qsTr("Receive on account") : qsTrId("from-account")
                 reset: function() {
                     accounts = Qt.binding(function() { return walletModel.accounts })
                     selectedAccount = Qt.binding(function() { return walletModel.currentAccount })
@@ -54,13 +54,13 @@ ModalPopup {
                 id: separator
                 anchors.top: selectFromAccount.bottom
                 anchors.topMargin: 19
+                icon.rotation: root.isRequested ? -90 : 90
             }
             RecipientSelector {
                 id: selectRecipient
                 accounts: walletModel.accounts
                 contacts: profileModel.addedContacts
-                //% "Recipient"
-                label: qsTrId("recipient")
+                label: qsTr("From")
                 readOnly: true
                 anchors.top: separator.bottom
                 anchors.topMargin: 10
@@ -114,6 +114,7 @@ ModalPopup {
             SVGImage {
                 width: 16
                 height: 16
+                visible: warningText.visible
                 source: "../../../../img/warning.svg"
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.bottom: warningText.top
@@ -122,6 +123,7 @@ ModalPopup {
 
             StyledText {
                 id: warningText
+                visible: !root.isRequested
                 //% "You need to request the recipient’s address first.\nAssets won’t be sent yet."
                 text: qsTrId("you-need-to-request-the-recipient-s-address-first--nassets-won-t-be-sent-yet-")
                 color: Style.current.danger
@@ -139,29 +141,14 @@ ModalPopup {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        StyledButton {
+        StatusRoundButton {
             id: btnBack
             anchors.left: parent.left
-            width: 44
-            height: 44
             visible: !stack.isFirstGroup
-            label: ""
-            background: Rectangle {
-                anchors.fill: parent
-                border.width: 0
-                radius: width / 2
-                color: btnBack.hovered ? Qt.darker(btnBack.btnColor, 1.1) : btnBack.btnColor
-
-                SVGImage {
-                    width: 20.42
-                    height: 15.75
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.verticalCenter: parent.verticalCenter
-                    fillMode: Image.PreserveAspectFit
-                    source: "../../../../img/arrow-right.svg"
-                    rotation: 180
-                }
-            }
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            rotation: 180
             onClicked: {
                 stack.back()
             }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/SendTransactionButton.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/SendTransactionButton.qml
@@ -14,8 +14,7 @@ Item {
     StyledText {
         id: signText
         color: Style.current.blue
-        //% "Sign and send"
-        text: qsTrId("sign-and-send")
+        text: qsTr("Sign and send")
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
         font.weight: Font.Medium

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/StateBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/StateBubble.qml
@@ -55,26 +55,16 @@ Rectangle {
         }
         text: {
             switch (root.state) {
-            //% "Pending"
-            case Constants.pending: return qsTrId("pending")
-            //% "Confirmed"
-            case Constants.confirmed: return qsTrId("status-confirmed")
-            //% "Unknown token"
-            case Constants.unknown: return qsTrId("unknown-token")
-            //% "Address requested"
-            case Constants.addressRequested: return qsTrId("address-requested")
-            //% "Waiting to accept"
-            case Constants.transactionRequested: return qsTrId("waiting-to-accept")
-            //% "Address shared"
-            //% "Address received"
-            case Constants.addressReceived: return (!root.outgoing ? qsTrId("address-shared") : qsTrId("address-received"))
+            case Constants.pending: return qsTr("Pending")
+            case Constants.confirmed: return qsTr("Confirmed")
+            case Constants.unknown: return qsTr("Unknown token")
+            case Constants.addressRequested: return qsTr("Address requested")
+            case Constants.transactionRequested: return qsTr("Waiting to accept")
+            case Constants.addressReceived: return (!root.outgoing ? qsTr("Address shared") : qsTr("Address received"))
             case Constants.transactionDeclined:
-            //% "Transaction declined"
-            case Constants.declined: return qsTrId("transaction-declined")
-            //% "Failure"
-            case Constants.failure: return qsTrId("failure")
-            //% "Unknown state"
-            default: return qsTrId("unknown-state")
+            case Constants.declined: return qsTr("Transaction declined")
+            case Constants.failure: return qsTr("failure")
+            default: return qsTr("Unknown state")
             }
         }
         font.weight: Font.Medium

--- a/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
+++ b/ui/app/AppLayouts/Chat/components/StickerPackPurchaseModal.qml
@@ -85,7 +85,7 @@ ModalPopup {
                     showBalanceForAssetSymbol = Qt.binding(function() { return root.asset.symbol })
                     minRequiredAssetBalance = Qt.binding(function() { return root.packPrice })
                 }
-                onSelectedAccountChanged: gasSelector.estimateGas()
+                onSelectedAccountChanged: if (isValid) { gasSelector.estimateGas() }
             }
             RecipientSelector {
                 id: selectRecipient
@@ -94,7 +94,6 @@ ModalPopup {
                 contacts: profileModel.addedContacts
                 selectedRecipient: { "address": utilsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
-                onSelectedRecipientChanged: gasSelector.estimateGas()
             }
             GasSelector {
                 id: gasSelector
@@ -196,11 +195,13 @@ ModalPopup {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        StyledButton {
+        StatusRoundButton {
             id: btnBack
             anchors.left: parent.left
-            //% "Back"
-            label: qsTrId("back")
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            rotation: 180
             onClicked: {
                 if (stack.isFirstGroup) {
                     return root.close()

--- a/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
@@ -81,7 +81,7 @@ ModalPopup {
                     showBalanceForAssetSymbol = Qt.binding(function() { return root.asset.symbol })
                     minRequiredAssetBalance = Qt.binding(function() { return root.ensPrice })
                 }
-                onSelectedAccountChanged: gasSelector.estimateGas()
+                onSelectedAccountChanged: if (isValid) { gasSelector.estimateGas() }
             }
             RecipientSelector {
                 id: selectRecipient
@@ -90,7 +90,7 @@ ModalPopup {
                 contacts: profileModel.addedContacts
                 selectedRecipient: { "address": utilsModel.ensRegisterAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
-                onSelectedRecipientChanged: gasSelector.estimateGas()
+                onSelectedRecipientChanged: if (isValid) { gasSelector.estimateGas() }
             }
             GasSelector {
                 id: gasSelector

--- a/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
@@ -85,7 +85,7 @@ ModalPopup {
                     showBalanceForAssetSymbol = Qt.binding(function() { return "ETH" })
                     minRequiredAssetBalance = Qt.binding(function() { return 0 })
                 }
-                onSelectedAccountChanged: gasSelector.estimateGas()
+                onSelectedAccountChanged: if (isValid) { gasSelector.estimateGas() }
             }
             RecipientSelector {
                 id: selectRecipient
@@ -94,7 +94,7 @@ ModalPopup {
                 contacts: profileModel.addedContacts
                 selectedRecipient: { "address": utilsModel.ensRegisterAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
-                onSelectedRecipientChanged: gasSelector.estimateGas()
+                onSelectedRecipientChanged: if (isValid) { gasSelector.estimateGas() }
             }
             GasSelector {
                 id: gasSelector

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -167,4 +167,8 @@ QtObject {
         let wordCount = countWords(text);
         return qsTr("%1%2 words").arg(getTick(wordCount)).arg(wordCount.toString());
     }
+
+    function uuid() {
+        return Date.now().toString(36) + Math.random().toString(36).substr(2, 5)
+    }
 }

--- a/ui/shared/ToastMessage.qml
+++ b/ui/shared/ToastMessage.qml
@@ -19,7 +19,7 @@ Popup {
     height: 68
     padding: 0
     margins: 0
-    width: Math.Max(Math.max(titleText.width, linkText.width) + toastImage.width + 12 * 4, 343)
+    width: Math.max(Math.max(titleText.width, linkText.width) + toastImage.width + 12 * 4, 343)
     x: parent.width - width - Style.current.bigPadding
     y: parent.height - height - Style.current.bigPadding
 

--- a/ui/shared/TransactionFormGroup.qml
+++ b/ui/shared/TransactionFormGroup.qml
@@ -6,4 +6,8 @@ FormGroup {
     id: root
     property string headerText
     property string footerText
+    property bool showBackBtn: true
+    property bool showNextBtn: true
+    property var onBackClicked
+    property var onNextClicked
 }

--- a/ui/shared/TransactionPreview.qml
+++ b/ui/shared/TransactionPreview.qml
@@ -15,6 +15,8 @@ Item {
     property var gas
     height: content.height
     property var reset: function() {}
+    signal fromClicked
+    signal gasClicked
 
     function resetInternal() {
         fromAccount = undefined
@@ -53,15 +55,39 @@ Item {
                     id: imgFromWallet
                     sourceSize.height: 18
                     sourceSize.width: 18
-                    anchors.right: parent.right
+                    anchors.right: fromArrow.visible ? fromArrow.left : parent.right
+                    anchors.rightMargin: fromArrow.visible ? Style.current.padding : 0
                     anchors.verticalCenter: parent.verticalCenter
                     fillMode: Image.PreserveAspectFit
                     source: "../app/img/walletIcon.svg"
+                    ColorOverlay {
+                        anchors.fill: parent
+                        source: parent
+                        color: root.fromAccount ? root.fromAccount.iconColor : Style.current.blue
+                    }
                 }
-                ColorOverlay {
-                    anchors.fill: imgFromWallet
-                    source: imgFromWallet
-                    color: root.fromAccount ? root.fromAccount.iconColor : Style.current.blue
+                SVGImage {
+                    id: fromArrow
+                    width: 13
+                    visible: typeof root.fromClicked === "function"
+                    anchors.right: parent.right
+                    anchors.rightMargin: 7
+                    anchors.verticalCenter: parent.verticalCenter
+                    fillMode: Image.PreserveAspectFit
+                    source: "../app/img/caret.svg"
+                    rotation: 270
+                    ColorOverlay {
+                        anchors.fill: parent
+                        visible: parent.visible
+                        source: parent
+                        color: Style.current.secondaryText
+                    }
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    visible: fromArrow.visible
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.fromClicked()
                 }
             }
         }
@@ -316,6 +342,7 @@ Item {
             id: itmNetworkFee
             //% "Network fee"
             label: qsTrId("network-fee")
+            visible: !!root.gas
             value: Item {
                 id: networkFeeRoot
                 anchors.fill: parent
@@ -362,10 +389,34 @@ Item {
                     height: 22
                     text: root.currency.toUpperCase()
                     color: Style.current.secondaryText
-                    anchors.right: parent.right
+                    anchors.right: gasArrow.visible ? gasArrow.left : parent.right
+                    anchors.rightMargin: gasArrow.visible ? Style.current.padding : 0
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignRight
                     verticalAlignment: Text.AlignVCenter
+                }
+                SVGImage {
+                    id: gasArrow
+                    width: 13
+                    visible: typeof root.gasClicked === "function"
+                    anchors.right: parent.right
+                    anchors.rightMargin: 7
+                    anchors.verticalCenter: parent.verticalCenter
+                    fillMode: Image.PreserveAspectFit
+                    source: "../app/img/caret.svg"
+                    rotation: 270
+                    ColorOverlay {
+                        anchors.fill: parent
+                        visible: parent.visible
+                        source: parent
+                        color: Style.current.secondaryText
+                    }
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    visible: gasArrow.visible
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.gasClicked()
                 }
             }
         }

--- a/ui/shared/TransactionStackView.qml
+++ b/ui/shared/TransactionStackView.qml
@@ -10,13 +10,14 @@ StackView {
     property bool isFirstGroup: currentIdx === 0
     signal groupActivated(Item group)
     property alias currentGroup: root.currentItem
+    readonly property string uuid: Utils.uuid()
+
     property var next: function() {
         if (groups && groups.length <= currentIdx + 1) {
             return
         }
         const group = groups[++currentIdx]
         this.push(group, StackView.Immediate)
-
     }
     property var back: function() {
         if (currentIdx <= 0) {

--- a/ui/shared/status/StatusStickerPackPurchaseModal.qml
+++ b/ui/shared/status/StatusStickerPackPurchaseModal.qml
@@ -85,7 +85,7 @@ ModalPopup {
                     showBalanceForAssetSymbol = Qt.binding(function() { return root.asset.symbol })
                     minRequiredAssetBalance = Qt.binding(function() { return root.packPrice })
                 }
-                onSelectedAccountChanged: gasSelector.estimateGas()
+                onSelectedAccountChanged: if (isValid) { gasSelector.estimateGas() }
             }
             RecipientSelector {
                 id: selectRecipient
@@ -94,7 +94,7 @@ ModalPopup {
                 contacts: profileModel.addedContacts
                 selectedRecipient: { "address": utilsModel.stickerMarketAddress, "type": RecipientSelector.Type.Address }
                 readOnly: true
-                onSelectedRecipientChanged: gasSelector.estimateGas()
+                onSelectedRecipientChanged: if (isValid) { gasSelector.estimateGas() }
             }
             GasSelector {
                 id: gasSelector
@@ -196,11 +196,13 @@ ModalPopup {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        StyledButton {
+        StatusRoundButton {
             id: btnBack
             anchors.left: parent.left
-            //% "Back"
-            label: qsTrId("back")
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            rotation: 180
             onClicked: {
                 if (stack.isFirstGroup) {
                     return root.close()


### PR DESCRIPTION
I noticed that the 1:1 chat commands were not able to send token transactions due to "intrinsic gas too low" error. I quickly realised there there were a few components missing, which have been fixed.

**feat: update the 1:1 chat commands transaction modal to allow editing of the from account and network fee**
The TransactionStackGroup was updated slightly to allow manual control of back/next actions.

Fixes #870.

**fix: Create distinct modal transaction actions**
Previously, adding `Connection`s for the  `walletModel.transactionWasSent` signal in different dialogs would cause the signal to be handled in the wrong dialog. The solution was to pass a `uuid` from the requesting dialog, and include the `uuid` in the response, so that only requests that were requested from the dialog would be handled.

**fix: update 1:1 translations**
All the translations were not being translated for me. I noticed that they did not exist in the `.ts` translation files either.