### PR TITLE
fix: "Generate new keys" not clickable

### DIFF
--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -181,24 +181,17 @@ Item {
             }
         }
 
-        MouseArea {
-            id: generateKeysLink
-            width: generateKeysLinkText.width
-            height: generateKeysLinkText.height
-            cursorShape: Qt.PointingHandCursor
+        StatusButton {
+            id: generateKeysLinkText
+            //% "Generate new keys"
+            text: qsTrId("generate-new-keys")
             anchors.top: txtPassword.bottom
             anchors.topMargin: 26
             anchors.horizontalCenter: parent.horizontalCenter
+            font.pixelSize: 13
             onClicked: {
                 setCurrentFlow(false);
                 onGenKeyClicked()
-            }
-
-            StatusButton {
-                id: generateKeysLinkText
-                //% "Generate new keys"
-                text: qsTrId("generate-new-keys")
-                font.pixelSize: 13
             }
         }
     }


### PR DESCRIPTION
On the Login screen, the "generate new keys" button was not clickable since the most recent update to the button.