### PR TITLE
refactor: make event emitter threadsafe

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,9 +40,6 @@
 [submodule "vendor/isaac"]
 	path = vendor/isaac
 	url = https://github.com/pragmagic/isaac.git
-[submodule "vendor/eventemitter"]
-	path = vendor/eventemitter
-	url = https://github.com/al-bimani/eventemitter.git
 [submodule "vendor/nim-libp2p"]
 	path = vendor/nim-libp2p
 	url = https://github.com/status-im/nim-libp2p

--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -1,4 +1,4 @@
-import NimQml, eventemitter, chronicles, tables
+import NimQml, chronicles, tables
 import ../../status/chat as chat_model
 import ../../status/mailservers as mailserver_model
 import ../../status/messages as messages_model
@@ -7,6 +7,7 @@ import ../../status/libstatus/types as status_types
 import ../../status/libstatus/settings as status_settings
 import ../../status/[chat, contacts, status, wallet, stickers]
 import view, views/channels_list, views/message_list
+import ../../eventemitter
 
 logScope:
   topics = "chat-controller"

--- a/src/app/login/core.nim
+++ b/src/app/login/core.nim
@@ -1,9 +1,10 @@
-import NimQml, eventemitter, chronicles, options, std/wrapnils
+import NimQml, chronicles, options, std/wrapnils
 import ../../status/libstatus/types as status_types
 import ../../status/signals/types
 import ../../status/status
 import view
 import ../../status/accounts as status_accounts
+import ../../eventemitter
 
 type LoginController* = ref object
   status*: Status

--- a/src/app/node/core.nim
+++ b/src/app/node/core.nim
@@ -2,7 +2,7 @@ import NimQml, chronicles
 import ../../status/signals/types
 import ../../status/[status, node, network]
 import ../../status/libstatus/types as status_types
-import eventemitter
+import ../../eventemitter
 import view
 
 logScope:

--- a/src/app/onboarding/core.nim
+++ b/src/app/onboarding/core.nim
@@ -1,9 +1,10 @@
-import NimQml, eventemitter, chronicles, std/wrapnils
+import NimQml, chronicles, std/wrapnils
 import ../../status/libstatus/types as status_types
 import ../../status/libstatus/accounts as status_accounts
 import ../../status/accounts as AccountModel
 import ../../status/status
 import ../../status/signals/types
+import ../../eventemitter
 import view
 
 type OnboardingController* = ref object

--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -1,4 +1,4 @@
-import NimQml, json, eventemitter, strutils, sugar, sequtils
+import NimQml, json, strutils, sugar, sequtils
 import json_serialization
 import ../../status/libstatus/mailservers as status_mailservers
 import ../../status/signals/types
@@ -11,6 +11,7 @@ import ../../status/chat as status_chat
 import ../../status/devices
 import ../../status/chat/chat
 import ../../status/wallet
+import ../../eventemitter
 import view
 import views/ens_manager
 import chronicles

--- a/src/app/wallet/core.nim
+++ b/src/app/wallet/core.nim
@@ -1,4 +1,4 @@
-import NimQml, eventemitter, strformat, strutils, chronicles
+import NimQml, strformat, strutils, chronicles
 
 import view
 import views/[asset_list, account_list, account_item]
@@ -8,6 +8,7 @@ import ../../status/libstatus/types as status_types
 import ../../status/signals/types
 import ../../status/[status, wallet]
 import ../../status/wallet/account as WalletTypes
+import ../../eventemitter
 
 type WalletController* = ref object
   status: Status

--- a/src/eventemitter.nim
+++ b/src/eventemitter.nim
@@ -1,0 +1,52 @@
+import # system libs
+  tables
+
+import # deps
+  uuids
+
+type 
+  Args* = ref object of RootObj # ...args
+  Handler* = proc (args: Args) {.closure.} # callback function type
+  EventEmitter* = ref object
+    events: Table[string, Table[UUID, Handler]]
+
+proc createEventEmitter*(): EventEmitter = 
+  result.new
+  result.events = initTable[string, Table[UUID, Handler]]()
+
+
+proc on(this: EventEmitter, name: string, handlerId: UUID, handler: Handler): void =
+  if this.events.hasKey(name):
+    this.events[name].add handlerId, handler
+    return
+  
+  this.events[name] = [(handlerId, handler)].toTable
+
+proc on*(this: EventEmitter, name: string, handler: Handler): void = 
+  var uuid: UUID
+  this.on(name, uuid, handler)
+
+proc once*(this:EventEmitter, name:string, handler:Handler): void =
+  var handlerId = genUUID()
+  this.on(name, handlerId) do(a: Args):
+    handler(a)
+    this.events[name].del handlerId
+
+proc emit*(this:EventEmitter, name:string, args:Args): void  =
+  if this.events.hasKey(name):
+    for (id, handler) in this.events[name].pairs:
+      handler(args)
+
+when isMainModule:
+  block:
+    type ReadyArgs = ref object of Args
+      text: string
+    var evts = createEventEmitter()
+    evts.on("ready") do(a: Args):
+      var args = ReadyArgs(a)
+      echo args.text, ": from [1st] handler"
+    evts.once("ready") do(a: Args):
+      var args = ReadyArgs(a)
+      echo args.text, ": from [2nd] handler"
+    evts.emit("ready", ReadyArgs(text:"Hello, World"))
+    evts.emit("ready", ReadyArgs(text:"Hello, World"))

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, eventemitter, chronicles, os, strformat
+import NimQml, chronicles, os, strformat
 
 import app/chat/core as chat
 import app/wallet/core as wallet
@@ -11,6 +11,7 @@ import status/signals/core as signals
 import status/libstatus/types
 import nim_status
 import status/status as statuslib
+import ./eventemitter
 
 var signalsQObjPointer: pointer
 

--- a/src/status/accounts.nim
+++ b/src/status/accounts.nim
@@ -1,8 +1,9 @@
-import eventemitter, options, chronicles, json
+import options, chronicles, json
 import libstatus/accounts as status_accounts
 import libstatus/settings as status_settings
 import libstatus/types
 import libstatus/utils
+import ../eventemitter
 
 type
   AccountModel* = ref object

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -1,10 +1,11 @@
-import eventemitter, json, strutils, sequtils, tables, chronicles, times
+import json, strutils, sequtils, tables, chronicles, times
 import libstatus/chat as status_chat
 import libstatus/mailservers as status_mailservers
 import libstatus/chatCommands as status_chat_commands
 import libstatus/accounts/constants as constants
 import libstatus/types
 import stickers
+import ../eventemitter
 
 import profile/profile
 import contacts

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -1,6 +1,7 @@
-import eventemitter, json, sequtils
+import json, sequtils
 import libstatus/contacts as status_contacts
 import profile/profile
+import ../eventemitter
 
 const DELETE_CONTACT* = "__deleteThisContact__"
 

--- a/src/status/libstatus/types.nim
+++ b/src/status/libstatus/types.nim
@@ -1,6 +1,7 @@
-import eventemitter, json, options, typetraits
+import json, options, typetraits
 import web3/ethtypes, json_serialization, stint
 import accounts/constants
+import ../../eventemitter
 
 type SignalType* {.pure.} = enum
   Message = "messages.new"

--- a/src/status/mailservers.nim
+++ b/src/status/mailservers.nim
@@ -1,7 +1,8 @@
-import algorithm, json, random, math, os, tables, sets, chronicles, eventemitter, sequtils, locks, sugar
+import algorithm, json, random, math, os, tables, sets, chronicles, sequtils, locks, sugar
 import libstatus/core as status_core
 import libstatus/chat as status_chat
 import libstatus/mailservers as status_mailservers
+import ../eventemitter
 
 
 # How do mailserver should work ?

--- a/src/status/messages.nim
+++ b/src/status/messages.nim
@@ -1,5 +1,6 @@
-import tables, sets, eventemitter
+import tables, sets
 import libstatus/chat
+import ../eventemitter
 
 type
   MessageDetails* = object

--- a/src/status/network.nim
+++ b/src/status/network.nim
@@ -1,4 +1,5 @@
-import chronicles, eventemitter
+import chronicles
+import ../eventemitter
 
 logScope:
   topics = "network-model"

--- a/src/status/node.nim
+++ b/src/status/node.nim
@@ -1,5 +1,5 @@
-import eventemitter
 import libstatus/core as status
+import ../eventemitter
 
 type NodeModel* = ref object
   events*: EventEmitter

--- a/src/status/profile.nim
+++ b/src/status/profile.nim
@@ -1,8 +1,9 @@
-import json, eventemitter
+import json
 import libstatus/types
 import profile/profile
 import libstatus/core as libstatus_core
 import libstatus/accounts as status_accounts
+import ../eventemitter
 
 type
   ProfileModel* = ref object

--- a/src/status/signals/core.nim
+++ b/src/status/signals/core.nim
@@ -1,7 +1,8 @@
-import NimQml, eventemitter, tables, json, chronicles, strutils, json_serialization
+import NimQml, tables, json, chronicles, strutils, json_serialization
 import ../libstatus/types as status_types
 import types, messages, discovery, whisperFilter, envelopes, expired, wallet
 import ../status
+import ../../eventemitter
 
 logScope:
   topics = "signals"

--- a/src/status/signals/types.nim
+++ b/src/status/signals/types.nim
@@ -2,7 +2,7 @@ import json, chronicles, json_serialization, tables
 import ../libstatus/types
 import ../chat/[chat, message]
 import ../profile/[profile, devices]
-import eventemitter
+import ../../eventemitter
 
 type Signal* = ref object of Args
   signalType* {.serializedFieldName("type").}: SignalType

--- a/src/status/status.nim
+++ b/src/status/status.nim
@@ -1,10 +1,9 @@
-import eventemitter
-
 import libstatus/accounts as libstatus_accounts
 import libstatus/core as libstatus_core
 import libstatus/settings as libstatus_settings
 import libstatus/types as libstatus_types
 import chat, accounts, wallet, node, network, mailservers, messages, contacts, profile, stickers
+import ../eventemitter
 
 export chat, accounts, node, mailservers, messages, contacts, profile, network
 

--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -2,12 +2,12 @@ import # global deps
   tables, strutils, sequtils
 
 import # project deps
-  chronicles, web3/[ethtypes, conversions], eventemitter, stint
+  chronicles, web3/[ethtypes, conversions], stint
 
 import # local deps
   libstatus/types, libstatus/eth/contracts as status_contracts,
   libstatus/stickers as status_stickers, transactions,
-  libstatus/wallet
+  libstatus/wallet, ../eventemitter
 from libstatus/utils as libstatus_utils import eth2Wei, gwei2Wei, toUInt64, parseAddress
 
 

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -1,4 +1,4 @@
-import eventemitter, json, strformat, strutils, chronicles, sequtils, httpclient, tables
+import json, strformat, strutils, chronicles, sequtils, httpclient, tables
 import json_serialization, stint
 from web3/ethtypes import Address, EthSend, Quantity
 from web3/conversions import `$`
@@ -14,6 +14,7 @@ from libstatus/types import PendingTransactionType, GeneratedAccount, DerivedAcc
 from libstatus/utils as libstatus_utils import eth2Wei, gwei2Wei, first, toUInt64, parseAddress
 import wallet/[balance_manager, account, collectibles]
 import transactions
+import ../eventemitter
 export account, collectibles
 export Transaction
 

--- a/src/status/wallet/account.nim
+++ b/src/status/wallet/account.nim
@@ -1,4 +1,4 @@
-from eventemitter import Args
+from ../../eventemitter import Args
 import ../libstatus/types
 
 type CollectibleList* = ref object


### PR DESCRIPTION
The event emitter was firing multiple times or not at all for events when multiple threads were involved. First, I started by adding references to objects in the events array, but ended up not being enough. Instead, a refactor of the library was easier and more robust.