### PR TITLE
feat: listen to add and ban events and update the dictionnary

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -70,7 +70,7 @@ StackLayout {
     Connections {
         target: chatView
         onUserAllowedFetched: {
-            if (pubkey === profileModel.profile.pubKey && chatId === chatsModel.activeChannel.name) {
+            if (hashedChatId === utilsModel.channelHash(chatsModel.activeChannel.name).toLowerCase() && address === utilsModel.derivedAnUserAddress(profileModel.profile.pubKey).toLowerCase()) {
                 chatColumnLayout.isUserAllowed = allowed
             }
         }

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -51,7 +51,7 @@ Item {
         enabled: contentType !== Constants.chatIdentifier && contentType !== Constants.fetchMoreMessagesButton
         target: chatView
         onUserAllowedFetched: {
-            if (pubkey === fromAuthor && chatId === chatsModel.activeChannel.name) {
+            if (hashedChatId === utilsModel.channelHash(chatsModel.activeChannel.name).toLowerCase() && address === utilsModel.derivedAnUserAddress(fromAuthor).toLowerCase()) {
                 messageItem.visible = allowed;
             }
         }

--- a/ui/app/AppLayouts/POA/main.js
+++ b/ui/app/AppLayouts/POA/main.js
@@ -804,10 +804,12 @@ const abi = [
     "function banUser(bytes32 channelId, address user)",
     "function getOperators(bytes32 channelId) view returns (address[])",
     "function getUsers(bytes32 channelId) view returns (address[])",
-    "function channels(bytes32 channelId) view returns (address)"
+    "function channels(bytes32 channelId) view returns (address)",
+    "event UserAllowed(bytes32 indexed channelId, address indexed user, address operator)",
+    "event UserBanned(bytes32 indexed channelId, address indexed user, address operator)"
 ];
 
-const contractAddress = "0xA79de68E3ffE354Df28eBd638e3FD24f4c41477d";
+const contractAddress = "0xFE0b7364335601c5eD4c024659A58E8Be304CdA8";
 
 
 window.onload = function(){
@@ -820,11 +822,23 @@ window.onload = function(){
       backend.response(messageId, JSON.stringify(data));
     }
 
+    const sendEvent = (event, data) => {
+      backend.sendEvent(event, JSON.stringify(data));
+    }
+
     const sendError = (messageId, error) => {
         backend.error(messageId, error.message);
       }
 
     let contract = new ethers.Contract(contractAddress, abi, provider);
+
+    contract.on("UserAllowed", (channelId, user, operator) => {
+        sendEvent("UserAllowed", {channelId, user, operator})
+    });
+
+    contract.on("UserBanned", (channelId, user, operator) => {
+        sendEvent("UserBanned", {channelId, user, operator})
+    });
  
     const onRequest = async function(req){
       let request = JSON.parse(req);

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -22,8 +22,16 @@ RowLayout {
         property int messageId: 0
 
         property var cbDictionary: ({})
+        property var eventDictionnary: ({})
 
         signal post(string data);
+
+        function subscribeToEvent(event, cb) {
+            if (!eventDictionnary[event]) {
+                eventDictionnary[event] = []
+            }
+            eventDictionnary[event].push(cb)
+        }
 
         function postMessage(data, cb) {
             messageId++;
@@ -37,6 +45,19 @@ RowLayout {
             var responseData = JSON.parse(data);
             if(cbDictionary[requestId]){
                 cbDictionary[requestId](responseData);
+            }
+        }
+
+        function sendEvent(event, data) {
+            try {
+                const parsedData = JSON.parse(data)
+                if (eventDictionnary[event]) {
+                    eventDictionnary[event].forEach(cb => {
+                                                        cb(parsedData)
+                                                    })
+                }
+            } catch (e) {
+                console.error("Error parsing event", e, data)
             }
         }
 

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -62,6 +62,6 @@ QtObject {
     readonly property string permission_contactCode: "contact-code"
 
 
-    readonly property string channelsContractAddress: "0xA79de68E3ffE354Df28eBd638e3FD24f4c41477d"
+    readonly property string channelsContractAddress: "0xFE0b7364335601c5eD4c024659A58E8Be304CdA8"
 
 }


### PR DESCRIPTION
I had to change the dictionnary to contain the channelHash and the userAddress instead of the chatid and pubkey, since the contract only contains the former and we cannot unhash.