### PR TITLE
Fix scroll at bottom when switching chats and with the button

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -99,19 +99,17 @@ ScrollView {
                 // User has scrolled up, we don't want to scroll back
                 return false
             }
-            if (caller) {
-                if (caller !== chatLogView.itemAtIndex(chatLogView.count - 1)) {
-                    // If we have a caller, only accept its request if it's the last message
-                    return false
-                }
-                // Add a small delay because images, even though they say they say they are loaed, they aren't shown yet
-                timer.setTimeout(function() {
-                    Qt.callLater(chatLogView.positionViewAtEnd)
-                }, 100);
-                return true
+            if (caller && caller !== chatLogView.itemAtIndex(chatLogView.count - 1)) {
+                // If we have a caller, only accept its request if it's the last message
+                return false
             }
-
+            // Call this twice and with a timer since the first scroll to bottom might have happened before some stuff loads
+            // meaning that the scroll will not actually be at the bottom on switch
+            // Add a small delay because images, even though they say they say they are loaed, they aren't shown yet
             Qt.callLater(chatLogView.positionViewAtEnd)
+            timer.setTimeout(function() {
+                 Qt.callLater(chatLogView.positionViewAtEnd)
+            }, 100);
             return true
         }
 
@@ -138,10 +136,7 @@ ScrollView {
             }
 
             onAppReady: {
-                // Add an additionnal delay, since the app can be "ready" just milliseconds before the UI updated to show the chat
-                timer.setTimeout(function() {
-                    chatLogView.scrollToBottom(true)
-                }, 500);
+                chatLogView.scrollToBottom(true)
             }
 
             onMessageNotificationPushed: function(chatId, msg, messageType, chatType, timestamp, identicon, username) {
@@ -149,7 +144,7 @@ ScrollView {
             }
         }
 
-        property var loadMsgs : Backpressure.oneInTime(chatLogView, 500, function() { 
+        property var loadMsgs : Backpressure.oneInTime(chatLogView, 500, function() {
             if(loadingMessages) return;
             loadingMessages = true;
             chatsModel.loadMoreMessages();

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/Sticker.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/Sticker.qml
@@ -11,6 +11,10 @@ Loader {
     sourceComponent: Component {
         Shared.ImageLoader {
             color: root.color
+            onLoaded: {
+                scrollToBottom(true, messageItem)
+            }
+
             width: 140
             height: this.visible ? 140 : 0
             source: this.visible ? ("https://ipfs.infura.io/ipfs/" + sticker) : ""

--- a/ui/shared/ImageLoader.qml
+++ b/ui/shared/ImageLoader.qml
@@ -6,6 +6,7 @@ Rectangle {
     id: root
     property alias source: image.source
     property alias fillMode: image.fillMode
+    signal loaded
     signal clicked
     color: Style.current.backgroundHover
     state: "loading"
@@ -131,6 +132,11 @@ Rectangle {
         horizontalAlignment: Image.AlignHCenter
         verticalAlignment: Image.AlignVCenter
         cache: true
+        onStatusChanged: {
+            if (image.status === Image.Ready) {
+                loaded()
+            }
+        }
         MouseArea {
             cursorShape: Qt.PointingHandCursor
             anchors.fill: parent


### PR DESCRIPTION
Fixes #1125

The problem seemed to happen when there was stickers at the bottom of a channel. We don't use the same loader and the one for stickers doesn't have the scroll to bottom call

Also, I added a double call to scroll to bottom, one straight away and one with a timer, because if you scroll down and the last elements are pictures or stickers, they will be small for the scroller, but once loaded, will take more space, hence creating a gap. With the timeout, the scroll goes to the right position after 100 ms. It's small enough that it's not too noticeable, but also long enough to let the images load again.