### PR TITLE
fix: don't close group info popup when closing profile popup

### DIFF
--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -291,7 +291,7 @@ ModalPopup {
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
-                            onClicked: openProfilePopup(model.userName, model.pubKey, model.identicon, '', contactRow.nickname, popup)
+                            onClicked: openProfilePopup(model.userName, model.pubKey, model.identicon, '', contactRow.nickname)
                         }
                     }
 


### PR DESCRIPTION
Fixes #1121 kindof

The profile popup already showed when clicking the name of someone. I only fixed it to not close when the profile popup closes