### PR TITLE
fix:  from/to account not showing correctly

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
@@ -97,22 +97,17 @@ ModalPopup {
         }
         TransactionFormGroup {
             id: group3
-            //% "Transaction preview"
-            headerText: qsTrId("transaction-preview")
+            headerText: root.isRequested ?
+                qsTr("Preview") :
+                //% "Transaction preview"
+                qsTrId("transaction-preview")
             footerText: root.finalButtonLabel
 
             TransactionPreview {
                 id: pvwTransaction
                 width: stack.width
                 fromAccount: root.isRequested ? selectRecipient.selectedRecipient : selectFromAccount.selectedAccount
-                isTransactionRequest: root.isRequested
-                toAccount: {
-                    if (root.isRequested) {
-                      selectFromAccount.selectedAccount.type = RecipientSelector.Type.Contact
-                      return selectFromAccount.selectedAccount
-                    }
-                    return selectRecipient.selectedRecipient
-                }
+                toAccount: root.isRequested ? selectFromAccount.selectedAccount : selectRecipient.selectedRecipient
                 asset: txtAmount.selectedAsset
                 amount: { "value": txtAmount.selectedAmount, "fiatValue": txtAmount.selectedFiatAmount }
                 currency: walletModel.defaultCurrency

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
@@ -68,7 +68,6 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: root.selectedAccount
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "Choose account"
@@ -77,7 +76,6 @@ ModalPopup {
                 minRequiredAssetBalance: parseFloat(root.selectedAmount)
                 reset: function() {
                     accounts = Qt.binding(function() { return walletModel.accounts })
-                    selectedAccount = Qt.binding(function() { return root.selectedAccount })
                     showBalanceForAssetSymbol = Qt.binding(function() { return root.selectedAsset.symbol })
                     minRequiredAssetBalance = Qt.binding(function() { return parseFloat(root.selectedAmount) })
                 }
@@ -147,12 +145,12 @@ ModalPopup {
                 id: gasValidator
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 8
-                selectedAccount: root.selectedAccount
+                selectedAccount: selectFromAccount.selectedAccount
                 selectedAmount: parseFloat(root.selectedAmount)
                 selectedAsset: root.selectedAsset
                 selectedGasEthValue: gasSelector.selectedGasEthValue
                 reset: function() {
-                    selectedAccount = Qt.binding(function() { return root.selectedAccount })
+                    selectedAccount = Qt.binding(function() { return selectFromAccount.selectedAccount })
                     selectedAmount = Qt.binding(function() { return parseFloat(root.selectedAmount) })
                     selectedAsset = Qt.binding(function() { return root.selectedAsset })
                     selectedGasEthValue = Qt.binding(function() { return gasSelector.selectedGasEthValue })
@@ -170,24 +168,23 @@ ModalPopup {
             onNextClicked: function() {
                 stack.push(groupSignTx, StackView.Immediate)
             }
-            isValid: groupSelectAcct.isValid && groupSelectGas.isValid && gasValidator.isValid && pvwTransaction.isValid
+            isValid: groupSelectAcct.isValid && groupSelectGas.isValid && pvwTransaction.isValid
 
             TransactionPreview {
                 id: pvwTransaction
                 width: stack.width
-                fromAccount: root.selectedAccount
+                fromAccount: selectFromAccount.selectedAccount
                 gas: {
                     "value": gasSelector.selectedGasEthValue,
                     "symbol": "ETH",
                     "fiatValue": gasSelector.selectedGasFiatValue
                 }
-                toAccount: root.selectedRecipient
+                toAccount: selectRecipient.selectedRecipient
                 asset: root.selectedAsset
                 amount: { "value": root.selectedAmount, "fiatValue": root.selectedFiatAmount }
                 currency: walletModel.defaultCurrency
-                //outgoing: root.outgoing
                 reset: function() {
-                    fromAccount =  Qt.binding(function() { return root.selectedAccount })
+                    fromAccount =  Qt.binding(function() { return selectFromAccount.selectedAccount })
                     gas = Qt.binding(function() {
                         return {
                             "value": gasSelector.selectedGasEthValue,
@@ -195,7 +192,7 @@ ModalPopup {
                             "fiatValue": gasSelector.selectedGasFiatValue
                         }
                     })
-                    toAccount =  Qt.binding(function() { return root.selectedRecipient })
+                    toAccount =  Qt.binding(function() { return selectRecipient.selectedRecipient })
                     asset = Qt.binding(function() { return root.selectedAsset })
                     amount = Qt.binding(function() { return { "value": root.selectedAmount, "fiatValue": root.selectedFiatAmount } })
                 }
@@ -208,12 +205,12 @@ ModalPopup {
                 id: gasValidator2
                 anchors.bottom: parent.bottom
                 anchors.bottomMargin: 8
-                selectedAccount: root.selectedAccount
+                selectedAccount: selectFromAccount.selectedAccount
                 selectedAmount: parseFloat(root.selectedAmount)
                 selectedAsset: root.selectedAsset
                 selectedGasEthValue: gasSelector.selectedGasEthValue
                 reset: function() {
-                    selectedAccount = Qt.binding(function() { return root.selectedAccount })
+                    selectedAccount = Qt.binding(function() { return selectFromAccount.selectedAccount })
                     selectedAmount = Qt.binding(function() { return parseFloat(root.selectedAmount) })
                     selectedAsset = Qt.binding(function() { return root.selectedAsset })
                     selectedGasEthValue = Qt.binding(function() { return gasSelector.selectedGasEthValue })

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/SendTransactionButton.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/SendTransactionButton.qml
@@ -7,7 +7,6 @@ Item {
     id: root
     width: parent.width
     height: childrenRect.height + Style.current.halfPadding
-    // property bool outgoing: true
 
     Separator {
         id: separator
@@ -48,7 +47,6 @@ Item {
         onOpened: {
           walletModel.getGasPricePredictions()
         }
-        selectedAccount: {}
         selectedRecipient: {
             return {
                 address: commandParametersObject.address,
@@ -60,7 +58,6 @@ Item {
         selectedAsset: token
         selectedAmount: tokenAmount
         selectedFiatAmount: fiatValue
-        //outgoing: root.outgoing
     }
 }
 

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -65,6 +65,9 @@ Item {
                 console.warn(qsTrId("cannot-find-asset---1---ensure-this-asset-has-been-added-to-the-token-list-").arg(showBalanceForAssetSymbol))
             }
         }
+        if (!selectedAccount.type) {
+            selectedAccount.type = RecipientSelector.Type.Account
+        }
         validate()
     }
 

--- a/ui/shared/BalanceValidator.qml
+++ b/ui/shared/BalanceValidator.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import "../imports"
+import "./status"
+
+IconButton {
+    id: root
+    property var account
+    property double amount
+    property var asset
+    property bool isValid: true
+    property var reset: function() {}
+    clickable: false
+    width: 13.33
+    height: 13.33
+    iconWidth: width
+    iconHeight: height    
+    iconName: "exclamation_outline"
+    color: Style.current.transparent
+    visible: !isValid
+
+    onAccountChanged: validate()
+    onAmountChanged: validate()
+    onAssetChanged: validate()
+
+    function resetInternal() {
+        account = undefined
+        amount = 0
+        asset = undefined
+        isValid = true
+    }
+
+    function validate() {
+        let isValid = true
+        if (!(account && account.assets && asset && amount > 0)) {
+            return root.isValid
+        }
+        const currAcctAsset = Utils.findAssetBySymbol(account.assets, asset.symbol)
+        
+        if (currAcctAsset && currAcctAsset.value < amount) {
+            isValid = false
+        }
+        root.isValid = isValid
+        return isValid
+    }
+
+    StatusToolTip {
+        id: tooltip
+        visible: parent.hovered
+        width: 100
+        text: qsTr("Insufficient balance")
+    }
+}

--- a/ui/shared/IconButton.qml
+++ b/ui/shared/IconButton.qml
@@ -15,7 +15,7 @@ RoundButton {
     icon.width: iconWidth
     icon.height: iconHeight
 
-    id: btnAddContainer
+    id: root
     width: 36
     height: 36
     radius: width / 2
@@ -29,8 +29,10 @@ RoundButton {
         id: imgIcon
         fillMode: Image.PreserveAspectFit
         source: "../app/img/" + parent.iconName + ".svg"
-        width: btnAddContainer.iconWidth
-        height: btnAddContainer.iconHeight
+        width: root.iconWidth
+        height: root.iconHeight
+        sourceSize.height: height * 2
+        sourceSize.width: width * 2
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
 
@@ -76,14 +78,14 @@ RoundButton {
     }
 
     onClicked: {
-        if (btnAddContainer.clickable) {
+        if (root.clickable) {
             imgIcon.state = "rotated"
         }
     }
 
     MouseArea {
         id: mouseArea
-        visible: btnAddContainer.clickable
+        visible: root.clickable
         anchors.fill: parent
         onPressed:  mouse.accepted = false
         cursorShape: Qt.PointingHandCursor


### PR DESCRIPTION
Fixes #1202

I had to revert the loader changes that switched from/to as it was causes quite a lot of logistical complexity. Instead of using Loaders, we are setting the type of account (account or contact), and it is being displayed appropriately. There is a very slight deviation from the design, however it is consistent with the design for other transaction previews.

feat: add BalanceValidator

Shows an exclamation icon next to the "from" account when the balance for the requested asset is too low.

This is useful when the user starts the transaction wizard on the TransactionPreview step.