### PR TITLE
feat: Re-enable contact selection in the wallet send dialog

### DIFF
--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -62,6 +62,17 @@ QtObject:
   QtProperty[bool] ensVerified:
     read = ensVerified
     notify = contactsUpdated
+  
+  proc alias*(self: ChatItemView): string {.slot.} = 
+    if self.chatItem != nil and
+      self.chatItem.chatType.isOneToOne and
+      self.status.chat.contacts.hasKey(self.chatItem.id):
+        return self.status.chat.contacts[self.chatItem.id].alias
+    result = ""
+
+  QtProperty[string] alias:
+    read = alias
+    notify = contactsUpdated
 
   proc color*(self: ChatItemView): string {.slot.} = result = ?.self.chatItem.color
 

--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -569,10 +569,12 @@ QtObject:
   proc ensWasResolved*(self: WalletView, resolvedAddress: string, uuid: string) {.signal.}
 
   proc ensResolved(self: WalletView, addressUuidJson: string) {.slot.} =
-    let
+    var
       parsed = addressUuidJson.parseJson
       address = parsed["address"].to(string)
       uuid = parsed["uuid"].to(string)
+    if address == "0x":
+      address = ""
     self.ensWasResolved(address, uuid)
   
   proc transactionCompleted*(self: WalletView, success: bool, txHash: string, revertReason: string = "") {.signal.}

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -259,6 +259,7 @@ StackLayout {
             selectRecipient.selectedRecipient: {
                 return {
                     address: Constants.zeroAddress, // Setting as zero address since we don't have the address yet
+                    alias: chatsModel.activeChannel.alias,
                     identicon: chatsModel.activeChannel.identicon,
                     name: chatsModel.activeChannel.name,
                     type: RecipientSelector.Type.Contact
@@ -270,6 +271,7 @@ StackLayout {
                 selectRecipient.selectedRecipient = Qt.binding(function() {
                     return {
                         address: Constants.zeroAddress, // Setting as zero address since we don't have the address yet
+                        alias: chatsModel.activeChannel.alias,
                         identicon: chatsModel.activeChannel.identicon,
                         name: chatsModel.activeChannel.name,
                         type: RecipientSelector.Type.Contact
@@ -294,6 +296,7 @@ StackLayout {
             selectRecipient.selectedRecipient: {
                 return {
                     address: Constants.zeroAddress, // Setting as zero address since we don't have the address yet
+                    alias: chatsModel.activeChannel.alias,
                     identicon: chatsModel.activeChannel.identicon,
                     name: chatsModel.activeChannel.name,
                     type: RecipientSelector.Type.Contact
@@ -305,6 +308,7 @@ StackLayout {
                 selectRecipient.selectedRecipient = Qt.binding(function() {
                     return {
                         address: Constants.zeroAddress, // Setting as zero address since we don't have the address yet
+                        alias: chatsModel.activeChannel.alias,
                         identicon: chatsModel.activeChannel.identicon,
                         name: chatsModel.activeChannel.name,
                         type: RecipientSelector.Type.Contact
@@ -326,25 +330,27 @@ StackLayout {
             selectRecipient.selectedRecipient: {
                 return {
                     address: "",
+                    alias: chatsModel.activeChannel.alias,
                     identicon: chatsModel.activeChannel.identicon,
                     name: chatsModel.activeChannel.name,
-                    type: RecipientSelector.Type.Address,
+                    type: RecipientSelector.Type.Contact,
                     ensVerified: true
                 }
             }
-            selectRecipient.selectedType: RecipientSelector.Type.Address
+            selectRecipient.selectedType: RecipientSelector.Type.Contact
             onReset: {
                 selectRecipient.readOnly = true
                 selectRecipient.selectedRecipient = Qt.binding(function() {
                     return {
                         address: "",
+                        alias: chatsModel.activeChannel.alias,
                         identicon: chatsModel.activeChannel.identicon,
                         name: chatsModel.activeChannel.name,
-                        type: RecipientSelector.Type.Address,
+                        type: RecipientSelector.Type.Contact,
                         ensVerified: true
                     }
                 })
-                selectRecipient.selectedType = RecipientSelector.Type.Address
+                selectRecipient.selectedType = RecipientSelector.Type.Contact
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -139,7 +139,8 @@ ModalPopup {
                         selectFromAccount.selectedAccount.address,
                         selectRecipient.selectedRecipient.address,
                         txtAmount.selectedAsset.address,
-                        txtAmount.selectedAmount))
+                        txtAmount.selectedAmount,
+                        ""))
 
                     if (!gasEstimate.success) {
                         //% "Error estimating gas: %1"

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -75,13 +75,16 @@ QtObject {
     }
 
     function isValidAddress(inputValue) {
-        return /^0x[a-fA-F0-9]{40}$/.test(inputValue)
+        return inputValue !== "0x" && /^0x[a-fA-F0-9]{40}$/.test(inputValue)
     }
 
     function isValidEns(inputValue) {
+        if (!inputValue) {
+            return false
+        }
         const isEmail = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/.test(inputValue)
         const isDomain = /(?:(?:(?<thld>[\w\-]*)(?:\.))?(?<sld>[\w\-]*))\.(?<tld>[\w\-]*)/.test(inputValue)
-        return isEmail || isDomain || inputValue.startsWith("@")
+        return isEmail || isDomain || (inputValue.startsWith("@") && inputValue.length > 1)
     }
 
 

--- a/ui/shared/AddressInput.qml
+++ b/ui/shared/AddressInput.qml
@@ -21,7 +21,17 @@ Item {
     height: inpAddress.height
 
     onSelectedAddressChanged: validate()
-    onTextChanged: ensResolver.resolveEns(text)
+    onTextChanged: {
+        metrics.text = text
+        root.isResolvedAddress = false
+        if (Utils.isValidAddress(text)) {
+            root.selectedAddress = text
+        } else {
+            root.selectedAddress = ""
+            root.validate()
+        }
+        ensResolver.resolveEns(text)
+    }
 
     function resetInternal() {
         selectedAddress = ""
@@ -62,13 +72,6 @@ Item {
             }
         }
         textField.rightPadding: 73
-        onTextEdited: {
-            metrics.text = text
-
-            ensResolver.resolveEns(text)
-            root.isResolvedAddress = false
-            root.selectedAddress = text
-        }
         TextMetrics {
             id: metrics
             elideWidth: 97
@@ -99,6 +102,7 @@ Item {
         onResolved: {
             root.isResolvedAddress = true
             root.selectedAddress = resolvedAddress
+            root.validate()
         }
         onIsPendingChanged: {
             if (isPending) {

--- a/ui/shared/AddressInput.qml
+++ b/ui/shared/AddressInput.qml
@@ -95,6 +95,7 @@ Item {
         anchors.top: inpAddress.bottom
         anchors.right: inpAddress.right
         anchors.topMargin: Style.current.halfPadding
+        debounceDelay: root.readOnly ? 0 : 600
         onResolved: {
             root.isResolvedAddress = true
             root.selectedAddress = resolvedAddress

--- a/ui/shared/ContactSelector.qml
+++ b/ui/shared/ContactSelector.qml
@@ -32,6 +32,13 @@ Item {
         isResolvedAddress = false
     }
 
+    function resolveEns() {
+        if (selectedContact.ensVerified) {
+            root.isResolvedAddress = false
+            ensResolver.resolveEns(selectedContact.name)
+        }
+    }
+
     onContactsChanged: {
         if (root.readOnly) {
             return
@@ -39,13 +46,7 @@ Item {
         root.selectedContact = { name: selectAContact }
     }
 
-    onSelectedContactChanged: {
-        if (selectedContact && selectedContact.ensVerified) {
-            root.isResolvedAddress = false
-            ensResolver.resolveEns(selectedContact.name)
-        }
-        validate()
-    }
+    onSelectedContactChanged: validate()
 
     function validate() {
         if (!selectedContact) {
@@ -138,11 +139,12 @@ Item {
         anchors.top: select.bottom
         anchors.right: select.right
         anchors.topMargin: Style.current.halfPadding
+        debounceDelay: root.readOnly ? 0 : 600
         onResolved: {
             root.isResolvedAddress = true
-            const { name, alias, isContact, identicon, ensVerified } = root.selectedContact
-            root.selectedContact = { address: resolvedAddress, name, alias, isContact, identicon, ensVerified }
-            validate()
+            var selectedContact = root.selectedContact
+            selectedContact.address = resolvedAddress
+            root.selectedContact = selectedContact
         }
         onIsPendingChanged: {
             if (isPending) {
@@ -228,6 +230,7 @@ Item {
                 anchors.fill: itemContainer
                 onClicked: {
                     root.selectedContact = { address, name, alias, isContact, identicon, ensVerified }
+                    resolveEns()
                     select.menu.close()
                 }
             }

--- a/ui/shared/ContactSelector.qml
+++ b/ui/shared/ContactSelector.qml
@@ -140,7 +140,8 @@ Item {
         anchors.topMargin: Style.current.halfPadding
         onResolved: {
             root.isResolvedAddress = true
-            root.selectedContact.address = resolvedAddress
+            const { name, alias, isContact, identicon, ensVerified } = root.selectedContact
+            root.selectedContact = { address: resolvedAddress, name, alias, isContact, identicon, ensVerified }
             validate()
         }
         onIsPendingChanged: {

--- a/ui/shared/EnsResolver.qml
+++ b/ui/shared/EnsResolver.qml
@@ -44,8 +44,8 @@ Item {
             if (uuid !== root.uuid) {
                 return
             }
-            root.resolved(resolvedAddress)
             root.isPending = false
+            root.resolved(resolvedAddress)
         }
     }
 }

--- a/ui/shared/EnsResolver.qml
+++ b/ui/shared/EnsResolver.qml
@@ -8,7 +8,8 @@ Item {
     id: root
     property bool isPending: false
     readonly property string uuid: Utils.uuid()
-    readonly property var validateAsync: Backpressure.debounce(inpAddress, 600, function (inputValue) {
+    property int debounceDelay: 600
+    readonly property var validateAsync: Backpressure.debounce(inpAddress, debounceDelay, function (inputValue) {
         root.isPending = true
         var name = inputValue.startsWith("@") ? inputValue.substring(1) : inputValue
         walletModel.resolveENS(name, uuid)

--- a/ui/shared/EnsResolver.qml
+++ b/ui/shared/EnsResolver.qml
@@ -1,0 +1,50 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.13
+import "../imports"
+
+Item {
+    id: root
+    property bool isPending: false
+    readonly property string uuid: Utils.uuid()
+    readonly property var validateAsync: Backpressure.debounce(inpAddress, 600, function (inputValue) {
+        root.isPending = true
+        var name = inputValue.startsWith("@") ? inputValue.substring(1) : inputValue
+        walletModel.resolveENS(name, uuid)
+    });
+    signal resolved(string resolvedAddress)
+
+    function resolveEns(name) {
+        if (Utils.isValidEns(name)) {
+            root.validateAsync(name)
+        }
+    }
+    width: 12
+    height: 12
+
+    Loader {
+        anchors.fill: parent
+        sourceComponent: loadingIndicator
+        active: root.isPending
+    }
+
+    Component {
+        id: loadingIndicator
+        LoadingImage {
+            width: root.width
+            height: root.height
+        }
+    }
+
+    Connections {
+        target: walletModel
+        onEnsWasResolved: {
+            if (uuid !== root.uuid) {
+                return
+            }
+            root.resolved(resolvedAddress)
+            root.isPending = false
+        }
+    }
+}

--- a/ui/shared/RecipientSelector.qml
+++ b/ui/shared/RecipientSelector.qml
@@ -113,6 +113,11 @@ Item {
                 break
             case RecipientSelector.Type.Contact:
                 selContact.selectedContact = selectedRecipient
+                // TODO: we shouldn't have to call resolveEns from the outside.
+                // It should be handled automatically when selectedContact is
+                // updated, however, handling it on property change causes an
+                // infinite loop
+                selContact.resolveEns()
                 selContact.visible = true
                 inpAddress.visible = selAccount.visible = false
                 break

--- a/ui/shared/RecipientSelector.qml
+++ b/ui/shared/RecipientSelector.qml
@@ -169,8 +169,10 @@ Item {
                 if (!selAddressSource.selectedSource || (selAddressSource.selectedSource && selAddressSource.selectedSource.value !== RecipientSelector.Type.Address)) {
                     return
                 }
-                root.selectedRecipient.address = selectedAddress
-                root.selectedRecipient.type = RecipientSelector.Type.Address
+                var recipient = root.selectedRecipient;
+                recipient.address = selectedAddress
+                recipient.type = RecipientSelector.Type.Address
+                root.selectedRecipient = recipient
             }
             onIsValidChanged: root.validate()
         }

--- a/ui/shared/RecipientSelector.qml
+++ b/ui/shared/RecipientSelector.qml
@@ -19,14 +19,26 @@ Item {
     //% "Invalid ethereum address"
     readonly property string addressValidationError: qsTrId("invalid-ethereum-address")
     property bool isValid: false
-    property bool isPending: false
+    property bool isPending: {
+        if (!selAddressSource.selectedSource) {
+            return false
+        }
+        switch (selAddressSource.selectedSource.value) {
+            case RecipientSelector.Type.Address:
+                return inpAddress.isPending
+            case RecipientSelector.Type.Contact:
+                return selContact.isPending
+            case RecipientSelector.Type.Account:
+                return selAccount.isPending
+        }
+    }
     property var reset: function() {}
     readonly property var sources: [
         //% "Address"
         { text: qsTrId("address"), value: RecipientSelector.Type.Address, visible: true },
         //% "My account"
         { text: qsTrId("my-account"), value: RecipientSelector.Type.Account, visible: true },
-        { text: qsTr("Contact"), value: RecipientSelector.Type.Contact, visible: false }
+        { text: qsTr("Contact"), value: RecipientSelector.Type.Contact, visible: true }
     ]
     property var selectedType: RecipientSelector.Type.Address
 
@@ -36,7 +48,19 @@ Item {
         selAccount.resetInternal()
         selAddressSource.resetInternal()
         isValid = false
-        isPending = false
+        isPending = Qt.binding(function() {
+            if (!selAddressSource.selectedSource) {
+                return false
+            }
+            switch (selAddressSource.selectedSource.value) {
+                case RecipientSelector.Type.Address:
+                    return inpAddress.isPending
+                case RecipientSelector.Type.Contact:
+                    return selContact.isPending
+                case RecipientSelector.Type.Account:
+                    return selAccount.isPending
+            }
+        })
         selectedType = RecipientSelector.Type.Address
         selectedRecipient = undefined
         accounts = undefined

--- a/ui/shared/RecipientSelector.qml
+++ b/ui/shared/RecipientSelector.qml
@@ -28,8 +28,8 @@ Item {
                 return inpAddress.isPending
             case RecipientSelector.Type.Contact:
                 return selContact.isPending
-            case RecipientSelector.Type.Account:
-                return selAccount.isPending
+            default:
+                return false
         }
     }
     property var reset: function() {}
@@ -174,10 +174,8 @@ Item {
                 if (!selAddressSource.selectedSource || (selAddressSource.selectedSource && selAddressSource.selectedSource.value !== RecipientSelector.Type.Address)) {
                     return
                 }
-                var recipient = root.selectedRecipient;
-                recipient.address = selectedAddress
-                recipient.type = RecipientSelector.Type.Address
-                root.selectedRecipient = recipient
+
+                root.selectedRecipient = { address: selectedAddress, type: RecipientSelector.Type.Address }
             }
             onIsValidChanged: root.validate()
         }


### PR DESCRIPTION
feat: Re-enable contact selection in the wallet send dialog

Selecting a ENS-verified contact will resolve it's ENS address so transactions can be sent directly to contacts from the wallet (if and only if they have ENS enabled for their account).

feat: add EnsResolver component that shows a loader and allows automated ENS resolution from within QML