### PR TITLE
[WIP] ci: provide INFURA_TOKEN to builds

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -52,7 +52,14 @@ pipeline {
     }
 
     stage('Client') {
-      steps { sh 'make nim_status_client' }
+      steps { 
+        withCredentials([string(
+          credentialsId: utils.getInfuraTokenCred(),
+          variable: 'INFURA_TOKEN'
+        )]) {
+          sh 'make nim_status_client'
+        }
+      }
     }
 
     stage('Package') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -48,7 +48,14 @@ pipeline {
     }
 
     stage('Client') {
-      steps { sh 'make nim_status_client' }
+      steps { 
+        withCredentials([string(
+          credentialsId: utils.getInfuraTokenCred(),
+          variable: 'INFURA_TOKEN'
+        )]) {
+          sh 'make nim_status_client'
+        }
+      }
     }
 
     stage('Package') { steps {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -58,7 +58,14 @@ pipeline {
     }
 
     stage('Package') {
-      steps { sh "make ${env.STATUS_CLIENT_ZIP}" }
+      steps { 
+        withCredentials([string(
+          credentialsId: utils.getInfuraTokenCred(),
+          variable: 'INFURA_TOKEN'
+        )]) {
+          sh "make ${env.STATUS_CLIENT_ZIP}"
+        }
+      }
     }
 
     stage('Parallel Upload') {


### PR DESCRIPTION
It was asked in `#desktop` how we could provide the infura token to CI builds. This is pretty much it.

Windows is slightly different because it doesn't run `make nim_status_client`. If I remember correctly that was to avoid rebuilds.