### PR TITLE
refactor: embed Infura key at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,17 +215,25 @@ $(FLEETFILE): | deps
 		| jq --indent 4 --sort-keys . \
 		> fleets.json
 
-remove-fleet: 
+remove-fleet:
 	rm -f fleets.json
 
 update-fleets: remove-fleet $(FLEETFILE)
-  
+
 rcc:
 	echo -e $(BUILD_MSG) "resources.rcc"
 	rm -f ./resources.rcc
 	rm -f ./ui/resources.qrc
 	./ui/generate-rcc.sh
 	rcc -binary ui/resources.qrc -o ./resources.rcc
+
+# default token is a free-tier token with limited capabilities and usage
+# limits; our docs should include directions for community contributor to setup
+# their own Infura account and token instead of relying on this default token
+# during development
+DEFAULT_TOKEN := 220a1abb4b6943a093c35d0ce4fb0732
+INFURA_TOKEN ?= $(DEFAULT_TOKEN)
+NIM_PARAMS += -d:INFURA_TOKEN:"$(INFURA_TOKEN)"
 
 nim_status_client: | $(DOTHERSIDE) $(STATUSGO) $(QRCODEGEN) $(FLEETFILE) rcc deps
 	echo -e $(BUILD_MSG) "$@" && \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -51,19 +51,15 @@ pipeline {
       steps { sh 'make status-go' }
     }
 
-    stage('Client') {
-      steps { 
+    stage('Package') {
+      steps {
         withCredentials([string(
           credentialsId: utils.getInfuraTokenCred(),
           variable: 'INFURA_TOKEN'
         )]) {
-          sh 'make nim_status_client'
+          sh 'make pkg-linux'
         }
       }
-    }
-
-    stage('Package') {
-      steps { sh 'make pkg-linux' }
     }
 
     stage('Parallel Upload') {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -47,35 +47,30 @@ pipeline {
       steps { sh 'make status-go' }
     }
 
-    stage('Client') {
-      steps { 
-        withCredentials([string(
-          credentialsId: utils.getInfuraTokenCred(),
-          variable: 'INFURA_TOKEN'
-        )]) {
-          sh 'make nim_status_client'
+    stage('Package') {
+      steps {
+        withCredentials([
+          string(
+            credentialsId: 'macos-keychain-identity',
+            variable: 'MACOS_CODESIGN_IDENT'
+          ),
+          string(
+            credentialsId: 'macos-keychain-pass',
+            variable: 'MACOS_KEYCHAIN_PASS'
+          ),
+          file(
+            credentialsId: 'macos-keychain-file',
+            variable: 'MACOS_KEYCHAIN_FILE'
+          ),
+          string(
+            credentialsId: utils.getInfuraTokenCred(),
+            variable: 'INFURA_TOKEN'
+          )
+        ]) {
+          sh 'make pkg-macos'
         }
       }
     }
-
-    stage('Package') { steps {
-      withCredentials([
-        string(
-          credentialsId: 'macos-keychain-identity',
-          variable: 'MACOS_CODESIGN_IDENT'
-        ),
-        string(
-          credentialsId: 'macos-keychain-pass',
-          variable: 'MACOS_KEYCHAIN_PASS'
-        ),
-        file(
-          credentialsId: 'macos-keychain-file',
-          variable: 'MACOS_KEYCHAIN_FILE'
-        ),
-      ]) {
-        sh 'make pkg-macos'
-      }
-    } }
 
     stage('Parallel Upload') {
       parallel {

--- a/src/status/libstatus/accounts/constants.nim
+++ b/src/status/libstatus/accounts/constants.nim
@@ -16,6 +16,18 @@ const PATH_DEFAULT_WALLET* = PATH_WALLET_ROOT & "/0"
 # EIP1581 Chat Key 0, the default whisper key
 const PATH_WHISPER* = PATH_EIP_1581 & "/0'/0"
 
+# set via `nim c` param `-d:INFURA_TOKEN:[token]`; should be set in CI/release builds
+const INFURA_TOKEN {.strdefine.} = ""
+# allow runtime override via environment variable; core contributors can set a
+# release token in this way for local development
+let INFURA_TOKEN_ENV = $getEnv("INFURA_TOKEN")
+
+let INFURA_TOKEN_RESOLVED =
+  if INFURA_TOKEN_ENV != "":
+    INFURA_TOKEN_ENV
+  else:
+    INFURA_TOKEN
+
 let DEFAULT_NETWORKS* = %* [
   {
     "id": "testnet_rpc",
@@ -26,7 +38,7 @@ let DEFAULT_NETWORKS* = %* [
       "DataDir": "/ethereum/testnet_rpc",
       "UpstreamConfig": {
         "Enabled": true,
-        "URL": "https://ropsten.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7"
+        "URL": "https://ropsten.infura.io/v3/" & INFURA_TOKEN_RESOLVED
       }
     }
   },
@@ -39,7 +51,7 @@ let DEFAULT_NETWORKS* = %* [
       "DataDir": "/ethereum/rinkeby_rpc",
       "UpstreamConfig": {
         "Enabled": true,
-        "URL": "https://rinkeby.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7"
+        "URL": "https://rinkeby.infura.io/v3/" & INFURA_TOKEN_RESOLVED
       }
     }
   },
@@ -65,7 +77,7 @@ let DEFAULT_NETWORKS* = %* [
       "DataDir": "/ethereum/mainnet_rpc",
       "UpstreamConfig": {
         "Enabled": true,
-        "URL": "https://mainnet.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7"
+        "URL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED
       }
     }
   },
@@ -133,16 +145,16 @@ var NODE_CONFIG* = %* {
     "MaxMessageDeliveryAttempts": 6,
     "PFSEnabled": true,
     "VerifyENSContractAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
-    "VerifyENSURL": "https://mainnet.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7",
+    "VerifyENSURL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED,
     "VerifyTransactionChainID": 1,
-    "VerifyTransactionURL": "https://mainnet.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7"
+    "VerifyTransactionURL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED
   },
   "StatusAccountsConfig": {
     "Enabled": true
   },
   "UpstreamConfig": {
     "Enabled": true,
-    "URL": "https://mainnet.infura.io/v3/7230123556ec4a8aac8d89ccd0dd74d7"
+    "URL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED
   },
   "WakuConfig": {
     "BloomFilterMode": nil,


### PR DESCRIPTION
Allow environmental override at runtime. Also, in the Makefile set a free-tier default token so that setting up an Infura account isn't strictly necessary for community contributors to build the app, even though in our docs it should be recommended they do so.

Core contributors should setup their own free-tier Infura account, create a key, and set it in the environment variable INFURA_TOKEN in their environment used to build the desktop app locally.

There is one aspect of this work that is incomplete. Ideally, in the handler for the `login` event the relevant settings in the database should always be updated with the resolved Infura key. However, when calling `getSetting[string](Setting.Networks_Networks)` in the handler it causes a segfault every time. Neither the reason for the crash nor a workaround have been worked out at this time.