### PR TITLE
feat: whitelist the characters possible for the channel names

### DIFF
--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -13,6 +13,7 @@ ModalPopup {
     property bool selectChatMembers: true
     property int memberCount: 1
     readonly property int maxMembers: 10
+    property string channelNameValidationError: ""
 
     onOpened: {
         groupName.text = "";
@@ -55,8 +56,25 @@ ModalPopup {
         }
     }
 
-    function doJoin(){
-        if(pubKeys.length === 0) return;
+    function validate() {
+        if (groupName.text === "") {
+            channelNameValidationError = qsTr("You need to enter a channel name")
+        } else if (!Utils.isValidChannelName(groupName.text)) {
+            channelNameValidationError = qsTr("The channel name can only contain lowercase letters, numbers and dashes")
+        } else {
+            channelNameValidationError = ""
+        }
+
+        return channelNameValidationError === ""
+    }
+
+    function doJoin() {
+        if (!validate()) {
+            return
+        }
+        if(pubKeys.length === 0) {
+            return;
+        }
         chatsModel.createGroup(Utils.filterXSS(groupName.text), JSON.stringify(pubKeys));
         popup.close();
     }
@@ -98,6 +116,7 @@ ModalPopup {
         //% "Group name"
         placeholderText: qsTrId("group-name")
         visible: !selectChatMembers
+        validationError: channelNameValidationError
     }
 
     Rectangle {

--- a/ui/app/AppLayouts/Chat/components/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PublicChatPopup.qml
@@ -8,8 +8,24 @@ import "../data/channelList.js" as ChannelJSON
 import "./"
 
 ModalPopup {
+    property string channelNameValidationError: ""
+
+    function validate() {
+        if (channelName.text === "") {
+            channelNameValidationError = qsTr("You need to enter a channel name")
+        } else if (!Utils.isValidChannelName(channelName.text)) {
+            channelNameValidationError = qsTr("The channel name can only contain lowercase letters, numbers and dashes")
+        } else {
+            channelNameValidationError = ""
+        }
+
+        return channelNameValidationError === ""
+    }
+
     function doJoin() {
-        if(channelName.text === "") return;
+        if (!validate()) {
+            return
+        }
         chatsModel.joinChat(channelName.text, Constants.chatTypePublic);
         popup.close();
     }
@@ -48,6 +64,7 @@ ModalPopup {
         Keys.onEnterPressed: doJoin()
         Keys.onReturnPressed: doJoin()
         icon: "../../../img/hash.svg"
+        validationError: channelNameValidationError
     }
 
     ScrollView {

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -146,6 +146,10 @@ QtObject {
         }
     }
 
+    function isValidChannelName(channelName) {
+        return (/^[a-z0-9\-]+$/.test(channelName))
+    }
+
     function isSpace(c) {
         return (/( |\t|\n|\r)/.test(c))
     }


### PR DESCRIPTION
Fixes ##1085

Adds a whitelist regex for the channel names. For now, only accepts lowercase letters, numbers and dashes.

This with the XSS filter in the other PR makes it pretty impossible to bamboozle us through the channel name