### PR TITLE
rcc: single dash options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ rcc:
 	rm -f ./resources.rcc
 	rm -f ./ui/resources.qrc
 	./ui/generate-rcc.sh
-	rcc --binary ui/resources.qrc -o ./resources.rcc
+	rcc -binary ui/resources.qrc -o ./resources.rcc
 
 nim_status_client: | $(DOTHERSIDE) $(STATUSGO) $(QRCODEGEN) $(FLEETFILE) rcc deps
 	echo -e $(BUILD_MSG) "$@" && \


### PR DESCRIPTION
According to help, options are single-dash - in fact, the default `rcc`
on fedora doesn't accept double-dash.

```
[arnetheduck@tempus nim-status-client]$ rcc --help
Qt resource compiler
rcc: Unknown option: '--help'
Usage: rcc  [options] <inputs>

Options:
  -o file              write output to file rather than stdout
  -name name           create an external initialization function with name
  -threshold level     threshold to consider compressing files
  -compress level      compress input files by level
  -root path           prefix resource access path with root path
  -no-compress         disable all compression
  -binary              output a binary file for use as a dynamic resource
  -namespace           turn off namespace macros
  -project             Output a resource file containing all
                       files from the current directory
  -version             display version
  -help                display this information
```
```
[arnetheduck@tempus nim-status-client]$ rcc --binary
Qt resource compiler
rcc: Unknown option: '--binary'
```