### PR TITLE
fix: fix notification banner showing the pubkey of group chats

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -330,7 +330,7 @@ QtObject:
   proc messagePushed*(self: ChatsView) {.signal.}
   proc newMessagePushed*(self: ChatsView) {.signal.}
 
-  proc messageNotificationPushed*(self: ChatsView, chatId: string, text: string, messageType: string, chatType: int, timestamp: string, identicon: string, username: string, hasMention: bool, isAddedContact: bool) {.signal.}
+  proc messageNotificationPushed*(self: ChatsView, chatId: string, text: string, messageType: string, chatType: int, timestamp: string, identicon: string, username: string, hasMention: bool, isAddedContact: bool, channelName: string) {.signal.}
 
   proc messagesCleared*(self: ChatsView) {.signal.}
 
@@ -358,7 +358,8 @@ QtObject:
               msg.identicon,
               msg.alias,
               msg.hasMention,
-              isAddedContact)
+              isAddedContact,
+              channel.name)
         else:
           discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
           self.newMessagePushed()

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -142,13 +142,13 @@ ScrollView {
                 chatLogView.scrollToBottom(true)
             }
 
-            onMessageNotificationPushed: function(chatId, msg, messageType, chatType, timestamp, identicon, username, hasMention, isAddedContact) {
+            onMessageNotificationPushed: function(chatId, msg, messageType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
                 if (appSettings.notificationSetting == Constants.notifyAllMessages || 
                     (appSettings.notificationSetting == Constants.notifyJustMentions && hasMention)) {
                         if (chatType === Constants.chatTypeOneToOne && !appSettings.allowNotificationsFromNonContacts && !isAddedContact) {
                             return
                         }
-                        notificationWindow.notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username)
+                        notificationWindow.notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username, channelName)
                 }
             }
         }

--- a/ui/shared/NotificationWindow.qml
+++ b/ui/shared/NotificationWindow.qml
@@ -17,6 +17,7 @@ Item {
     property string timestamp: "20/2/2020"
     property string identicon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQAQMAAAC6caSPAAAABlBMVEXMzMz////TjRV2AAAAAWJLR0QB/wIt3gAAACpJREFUGBntwYEAAAAAw6D7Uw/gCtUAAAAAAAAAAAAAAAAAAAAAAAAAgBNPsAABAjKCqQAAAABJRU5ErkJggg=="
     property string username: "@jonas"
+    property string channelName: "sic-mundus"
 
     property var processClick: Backpressure.oneInTime(root, 1000, function () {
         notificationSound.play()
@@ -53,15 +54,15 @@ Item {
 
             StatusNotification {
                 id: channelNotif
-                property string channelName: root.chatType === Constants.chatTypeOneToOne ? root.username : root.chatId
                 chatId: root.chatId
                 name: {
                   if (appSettings.notificationMessagePreviewSetting === Constants.notificationPreviewAnonymous) {
                       return "Status"
                   }
-                  return root.chatType !== Constants.chatTypePublic ?
-                          Emoji.parse(Utils.removeStatusEns(Utils.filterXSS(channelName)), "26x26") :
-                          "#" + Utils.filterXSS(channelName)
+                  if (root.chatType === Constants.chatTypePublic) {
+                      return root.chatId
+                  }
+                  return root.chatType === Constants.chatTypePrivateGroupChat ? Utils.filterXSS(root.channelName) : Utils.removeStatusEns(root.username)
                 }
                 message: {
                     if (appSettings.notificationMessagePreviewSetting > Constants.notificationPreviewNameOnly) {
@@ -112,7 +113,7 @@ Item {
         }
     }
 
-    function notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username) {
+    function notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username, channelName) {
         this.chatId = chatId
         this.message = msg
         this.messageType = parseInt(messageType, 10)
@@ -120,6 +121,7 @@ Item {
         this.timestamp = timestamp
         this.identicon = identicon
         this.username = username
+        this.channelName = channelName
         processClick()
     }
 }


### PR DESCRIPTION
Fixes #1305

The group chats notifications showed the channel's pubkey and no emoticons because it didn't know the channel name