### PR TITLE
fix: do not strip spaces from the parts of messages

### DIFF
--- a/src/app/chat/views/channels_list.nim
+++ b/src/app/chat/views/channels_list.nim
@@ -162,7 +162,7 @@ QtObject:
     case elem.textType:
     of "mention": result = self.userNameOrAlias(elem.literal)
     of "link": result = elem.destination
-    else: result = escape_html(elem.literal.strip)
+    else: result = escape_html(elem.literal)
 
   proc renderBlock(self: ChannelsList, message: Message): string =
     for pMsg in message.parsedText:
@@ -171,5 +171,5 @@ QtObject:
           for children in pMsg.children:
             result = result & self.renderInline(children)
         else:
-          result = escape_html(pMsg.literal.strip)
+          result = escape_html(pMsg.literal)
 


### PR DESCRIPTION
Fixes #1311

this caused spaces to disappear when using markdown

@richard-ramos I saw you were the one to add the strip. What was the original reasoning?
I tried without the  strip to adds multiple spaces, enters and markdowns and everything works
