### PR TITLE
fix: ensure reply text area shows emojis

### DIFF
--- a/ui/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/shared/status/StatusChatInputReplyArea.qml
@@ -6,7 +6,7 @@ import "../../shared"
 
 Rectangle {
     id: root
-    height: 50
+    height: 60
     color: Style.current.lightGrey
     radius: 16
     clip: true
@@ -51,7 +51,7 @@ Rectangle {
         font.pixelSize: 13
         font.weight: Font.Normal
         // Eliding only works for PlainText: https://bugreports.qt.io/browse/QTBUG-16567
-        textFormat: Text.PlainText
+        textFormat: Text.RichText
         color: Style.current.black
     }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-status-client/issues/1324

![2020-11-17-172344_272x122_scrot](https://user-images.githubusercontent.com/58890963/99410972-c1e75e00-28fb-11eb-9e11-72b92fb9138f.png)

