### PR TITLE
feat: enable animated gifs but stop them on click and out of focus

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -137,6 +137,9 @@ Item {
             ImageMessage {
                 color: Style.current.transparent
                 chatHorizontalPadding: 0
+                onClicked: {
+                    chatTextItem.clickMessage(false, false, true, image)
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
@@ -5,7 +5,7 @@ Rectangle {
     property int chatVerticalPadding: 12
     property int chatHorizontalPadding: 12
     property bool isCurrentUser: bool
-    signal clicked(string source)
+    signal clicked(var image)
 
     id: imageChatBox
     height: {
@@ -47,7 +47,7 @@ Rectangle {
             source: modelData
             isCurrentUser: imageChatBox.isCurrentUser
             onClicked: {
-                imageChatBox.clicked(source)
+                imageChatBox.clicked(image)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
@@ -11,9 +11,7 @@ MouseArea {
             clickMessage(false, isSticker, false);
             return;
         }
-        if (mouse.button & Qt.LeftButton) {
-            if (isImage && !isSticker)
-                clickMessage(false, false, isImage, image);
+        if (mouse.button & Qt.LeftButton) {                
             return;
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -221,7 +221,7 @@ Item {
         ImageMessage {
             isCurrentUser: messageItem.isCurrentUser
             onClicked: {
-              chatTextItem.clickMessage(false, false, true, source)
+                chatTextItem.clickMessage(false, false, true, image)
             }
         }
     }

--- a/ui/shared/status/StatusImageModal.qml
+++ b/ui/shared/status/StatusImageModal.qml
@@ -22,17 +22,17 @@ Popup {
     padding: 0
 
     function setPopupData(image) {
-        messageImage.source = image;
+        messageImage.source = image.source;
+        const maxHeight = applicationWindow.height - 80
+        const maxWidth = applicationWindow.width - 80
 
-        let maxHeight = applicationWindow.height - 80
-        let maxWidth = applicationWindow.width - 80
 
-        if (messageImage.sourceSize.width >= maxWidth || messageImage.sourceSize.height >= maxHeight) {
+        if (image.sourceSize.width >= maxWidth || image.sourceSize.height >= maxHeight) {
             this.width = maxWidth
             this.height = maxHeight
         } else {
-            this.width = messageImage.sourceSize.width
-            this.height = messageImage.sourceSize.height
+            this.width = image.sourceSize.width
+            this.height = image.sourceSize.height
         }
     }
 


### PR DESCRIPTION
Fixes #1330

Makes the Gifs play. It only needed `AnimatedImage` instead of `Image`.

I worried that "always" using `AnimatedImage` might have negative impact on memory or CPU usage, but I tested and it doesn't. Animated is basically just a wrapper around image that has like 5 extra properties.

Also, I made sure that no images keep playing while scrolled up and to make it less annoying, you can also stop the animation by clicking on the image or un-focusing the window

Two improvements/issues:
1. When scrolling and the image disappears, it gets completely thrown out of the memory (it's done automatically by ListView). It's cool for memory usage, but it means that once the image is back in the view, it has to re-render it. That also makes it so that if you stopped a gif before, scroll away and scroll back, it will play again.
2. We currently only support urls ending with `.gif`. I know Discord also supports straight up giphy and tenor links that don't end with `.gif`. I'm not sure how they do it, because they have an HTML content-type and not an image one. I guess they actually make a request to them and get the actual image from there. Might be a possible improvement