### PR TITLE
fix: remove errors on collectibles rpc errors

### DIFF
--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -45,7 +45,10 @@ proc tokenOfOwnerByIndex(contract: Erc721Contract, address: Address, index: Stui
       "data": contract.methods["tokenOfOwnerByIndex"].encodeAbi(tokenOfOwnerByIndex)
     }, "latest"]
     response = callPrivateRPC("eth_call", payload)
-    res = parseJson($response)["result"].str
+    jsonResponse = parseJson($response)
+  if (not jsonResponse.hasKey("result")):
+    return -1
+  let res = jsonResponse["result"].getStr
   if (res == "0x"):
     return -1
   result = fromHex[int](res)


### PR DESCRIPTION
Fixes #1325

The problem is that the request to get a token from the contract returns an error and we threw on it because there was no `result`.

Sadly, I don't think there is a way to not have the rpc error, because it's the contract itself responding with a revert when the address doesn't have a token instead of just retuning an "empty" result.