### PR TITLE
feat: support seeing who liked a message

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -10,12 +10,12 @@ Item {
     width: childrenRect.width
 
     function lastTwoItems(left, right) {
-        return left + " and " + right;
+        return qsTr("%1 and %2").arg(left, right);
     }
 
     function showReactionAuthors(fromAccounts) {
         if (fromAccounts.length < 3)
-            return fromAccounts.join(" and ");
+            return fromAccounts.join(qsTr(" and "));
 
         var leftNode = [];
         var rightNode = [];
@@ -25,7 +25,7 @@ Item {
             rightNode = fromAccounts.slice(3, fromAccounts.length);
             return (rightNode.length == 1) ?
                                 lastTwoItems(leftNode.join(", "), rightNode[0]) :
-                                lastTwoItems(leftNode.join(", "), `${rightNode.length} more reacted.`);
+                                lastTwoItems(leftNode.join(", "), qsTr("%1 more reacted.").arg(rightNode.length));
         }
 
         leftNode = fromAccounts.slice(0, 2);

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -9,6 +9,30 @@ Item {
     height: 20
     width: childrenRect.width
 
+    function lastTwoItems(left, right) {
+        return left + " and " + right;
+    }
+
+    function showReactionAuthors(fromAccounts) {
+        if (fromAccounts.length < 3)
+            return fromAccounts.join(" and ");
+
+        var leftNode = [];
+        var rightNode = [];
+
+        if (fromAccounts.length > 3) {
+            leftNode = fromAccounts.slice(0, 3);
+            rightNode = fromAccounts.slice(3, fromAccounts.length);
+            return (rightNode.length == 1) ?
+                                lastTwoItems(leftNode.join(", "), rightNode[0]) :
+                                lastTwoItems(leftNode.join(", "), `${rightNode.length} more reacted.`);
+        }
+
+        leftNode = fromAccounts.slice(0, 2);
+        rightNode = fromAccounts.slice(2, fromAccounts.length);
+        return lastTwoItems(leftNode.join(", "), rightNode[0]);
+    }
+
     Repeater {
         id: reactionepeater
         model: {
@@ -54,7 +78,7 @@ Item {
 
             ToolTip {
                 visible: mouseArea.containsMouse
-                text: modelData.fromAccounts.join(", ")
+                text: showReactionAuthors(modelData.fromAccounts)
             }
 
             // Rounded corner to cover one corner

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.3
+import QtQuick.Controls 2.13
 import "../../../../../shared"
 import "../../../../../imports"
 
@@ -23,11 +24,13 @@ Item {
                     if (!byEmoji[reaction.emojiId]) {
                         byEmoji[reaction.emojiId] = {
                             emojiId: reaction.emojiId,
+                            fromAccounts: [],
                             count: 0,
                             currentUserReacted: false
                         }
                     }
                     byEmoji[reaction.emojiId].count++;
+                    byEmoji[reaction.emojiId].fromAccounts.push(chatsModel.userNameOrAlias(reaction.from));
                     if (!byEmoji[reaction.emojiId].currentUserReacted && reaction.from === profileModel.profile.pubKey) {
                         byEmoji[reaction.emojiId].currentUserReacted = true
                     }
@@ -48,6 +51,11 @@ Item {
             anchors.left: (index === 0) ? parent.left: parent.children[index-1].right
             anchors.leftMargin: (index === 0) ? 0 : root.imageMargin
             color: modelData.currentUserReacted ? Style.current.primary : Style.current.inputBackground
+
+            ToolTip {
+                visible: mouseArea.containsMouse
+                text: modelData.fromAccounts.join(", ")
+            }
 
             // Rounded corner to cover one corner
             Rectangle {
@@ -95,7 +103,9 @@ Item {
             }
 
             MouseArea {
+                id: mouseArea
                 anchors.fill: parent
+                hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
                     chatsModel.toggleEmojiReaction(messageId, modelData.emojiId)


### PR DESCRIPTION
fixes https://github.com/status-im/nim-status-client/issues/1386

Added a tooltip that shows username or alias of chat keys stored in the emojiReactions model fromAccount attribute

![reaction should show who made them](https://user-images.githubusercontent.com/58890963/99948636-677a5180-2d82-11eb-9fdf-f2e868f1e4db.gif)
