### PR TITLE
fix: push notification even when message comes from active channel

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -345,11 +345,10 @@ QtObject:
       self.messageList[msg.chatId].add(msg)
       self.messagePushed()
       if self.channelOpenTime.getOrDefault(msg.chatId, high(int64)) < msg.timestamp.parseFloat.fromUnixFloat.toUnix:
-        if msg.chatId != self.activeChannel.id:
-          let channel = self.chats.getChannelById(msg.chatId)
-          if not channel.muted:
-            self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.messageType, channel.chatType.int, msg.timestamp, msg.identicon, msg.alias, msg.hasMention)
-        else:
+        let channel = self.chats.getChannelById(msg.chatId)
+        if not channel.muted:
+          self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.messageType, channel.chatType.int, msg.timestamp, msg.identicon, msg.alias, msg.hasMention)
+        if msg.chatId == self.activeChannel.id:
           discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
           self.newMessagePushed()
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -143,7 +143,10 @@ ScrollView {
             onMessageNotificationPushed: function(chatId, msg, messageType, chatType, timestamp, identicon, username, hasMention) {
                 if (appSettings.notificationSetting == Constants.notifyAllMessages || 
                     (appSettings.notificationSetting == Constants.notifyJustMentions && hasMention)) {
-                        notificationWindow.notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username)
+                    if (chatsModel.activeChannel.id == chatId && sLayout.currentIndex == Constants.appViewChat) {
+                        return
+                    }
+                    notificationWindow.notifyUser(chatId, msg, messageType, chatType, timestamp, identicon, username)
                 }
             }
         }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -210,6 +210,11 @@ RowLayout {
             Layout.fillHeight: true
         }
     }
+
+    NotificationWindow {
+        id: notificationWindow
+        activeView: sLayout.currentIndex
+    }
 }
 
 /*##^##

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -7,6 +7,8 @@ QtObject {
     readonly property int chatTypePublic: 2
     readonly property int chatTypePrivateGroupChat: 3
 
+    readonly property int appViewChat: 0
+
     readonly property int fetchRangeLast24Hours: 86400
     readonly property int fetchRangeLast2Days: 172800
     readonly property int fetchRangeLast3Days: 259200

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -294,10 +294,6 @@ ApplicationWindow {
             }
         }
     }
-
-    NotificationWindow {
-        id: notificationWindow
-    }
 }
 
 /*##^##


### PR DESCRIPTION
Prior to this commit, we would not push a notification when the message signal
has the same chat id as the currently active channel.

This caused some unexpected behaviour in which notifications wouldn't be shown
because the messages are received in the active channel, but the app may not be
"active" and in the background.

Another scenario where we need to ensure to push a notification is when a user
is using a different view than the chat (e.g. the wallet). Also here, a notification
should be pushed, even when the message channel is the same as the current active one.