### PR TITLE
lower number of artifacts to keep in CI to 10

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -16,8 +16,8 @@ pipeline {
     timeout(time: 15, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '20',
-      daysToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
     ))
   }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -11,8 +11,8 @@ pipeline {
     timeout(time: 15, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '20',
-      daysToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
     ))
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -9,8 +9,8 @@ pipeline {
     timeout(time: 25, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '20',
-      daysToKeepStr: '60',
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
     ))
   }
 


### PR DESCRIPTION
The artifacts from this repo are taking up too much space on the CI master:
```
admin@master-01.do-ams3.ci.misc:/docker/jenkins/data/jobs % sudo du -hsc ./* | sort -h | tail -n5
13G	./status-react
17G	./status-go
18G	./nimbus
73G	./nim-status-client
122G	total
```