### PR TITLE
fix: fix fleets.json file wrongly placed in Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ $(STATUS_CLIENT_ZIP): nim_status_client nim_windows_launcher $(NIM_WINDOWS_PREBU
 	cp status.ico tmp/windows/dist/Status/resources/
 	cp status.svg tmp/windows/dist/Status/resources/
 	cp resources.rcc tmp/windows/dist/Status/resources/
-	cp fleets.json tmp/windows/dist/Status/resources/
+	cp $(FLEETFILE) tmp/windows/dist/Status/
 	cp bin/nim_status_client.exe tmp/windows/dist/Status/bin/Status.exe
 	cp bin/nim_windows_launcher.exe tmp/windows/dist/Status/Status.exe
 	rcedit \


### PR DESCRIPTION
The fleets file was placed in resources but it was needed in the root 🤷 