### PR TITLE
fix: fix ChatImage not opening in the popup

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -62,11 +62,14 @@ Item {
         anchors.left: chatText.left
         anchors.leftMargin: 8
         anchors.top: chatReply.bottom
+        z: 51
+
 
         sourceComponent: Component {
             ChatImage {
                 imageSource: image
                 imageWidth: 200
+                onClicked: chatTextItem.clickMessage(false, false, true, image)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -135,16 +135,19 @@ Item {
             anchors.topMargin: Style.current.smallPadding
             anchors.left: parent.left
             anchors.leftMargin: chatBox.chatHorizontalPadding
+            z: 51
 
             sourceComponent: Component {
                 Item {
                     width: chatImageComponent.width + 2 * chatBox.chatHorizontalPadding
                     height: chatImageComponent.height
+
                     ChatImage {
                         id: chatImageComponent
                         imageSource: image
                         imageWidth: 250
                         isCurrentUser: messageItem.isCurrentUser
+                        onClicked: chatTextItem.clickMessage(false, false, true, image)
                     }
                 }
             }


### PR DESCRIPTION
It was missing the signal and also it needed a higher Z. I'm not sure why it needed the higher Z, since it didn't need it before