### PR TITLE
fix: wallet derivation paths for generated accounts , imported seed phrases and private keys

### DIFF
--- a/src/status/libstatus/accounts.nim
+++ b/src/status/libstatus/accounts.nim
@@ -269,7 +269,6 @@ proc saveAccount*(account: GeneratedAccount, password: string, color: string, ac
       address = account.address
       publicKey = account.publicKey
 
-    echo "SAVING ACCOUNT"
     echo callPrivateRPC("accounts_saveAccounts", %* [
       [{
         "color": color,

--- a/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
+++ b/ui/app/AppLayouts/Wallet/components/AddAccountWithPrivateKey.qml
@@ -122,7 +122,7 @@ ModalPopup {
                 return loading = false
             }
 
-            const error = walletModel.addAccountsFromPrivateKey(accountPKeyInput.text, passwordInput.text, accountNameInput.text, selectedColor)
+            const error = walletModel.addAccountsFromPrivateKey(accountPKeyInput.text, passwordInput.text, accountNameInput.text, accountColorInput.selectedColor)
             loading = false
             if (error) {
                 errorSound.play()


### PR DESCRIPTION
This fixes the issue with creating transactions. The derivation paths should change depending on the type of account being used. We were also missing calling a nim-status function when the private key are imported.