### PR TITLE
fix: stop crash by showing error message

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -66,6 +66,10 @@ proc handleChatEvents(self: ChatController) =
     self.status.messages.trackMessage(msg.id, msg.channel)
     self.view.sendingMessage()
 
+  self.status.events.on("sendingMessageFailed") do(e:Args):
+    var msg = MessageArgs(e)
+    self.view.sendingMessageFailed()
+
   self.status.events.on("messageSent") do(e:Args):
     var msg = MessageSentArgs(e)
     self.view.markMessageAsSent(msg.chatId, msg.id)

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -233,6 +233,8 @@ QtObject:
 
   proc appReady*(self: ChatsView) {.signal.}
 
+  proc sendingMessageFailed*(self: ChatsView) {.signal.}
+
   proc alias*(self: ChatsView, pubKey: string): string {.slot.} =
     generateAlias(pubKey)
 

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -198,9 +198,12 @@ proc setActiveChannel*(self: ChatModel, chatId: string) =
 proc processMessageUpdateAfterSend(self: ChatModel, response: string): (seq[Chat], seq[Message])  =
   result = self.processChatUpdate(parseJson(response))
   var (chats, messages) = result
-  self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
-  for msg in messages:
-    self.events.emit("sendingMessage", MessageArgs(id: msg.id, channel: msg.chatId))
+  if chats.len == 0 or messages.len == 0:
+    self.events.emit("sendingMessageFailed", MessageArgs())
+  else:
+    self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
+    for msg in messages:
+      self.events.emit("sendingMessage", MessageArgs(id: msg.id, channel: msg.chatId))
 
 proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int) =
   var response = status_chat.sendChatMessage(chatId, msg, replyTo, contentType)

--- a/src/status/chat/utils.nim
+++ b/src/status/chat/utils.nim
@@ -12,10 +12,10 @@ proc formatChatUpdate(response: JsonNode): (seq[Chat], seq[Message]) =
 proc processChatUpdate(self: ChatModel, response: JsonNode): (seq[Chat], seq[Message]) =
   var chats: seq[Chat] = @[]
   var messages: seq[Message] = @[]
-  if response["result"]{"chats"} != nil:
+  if response{"result"}{"chats"} != nil:
     for jsonMsg in response["result"]["messages"]:
       messages.add(jsonMsg.toMessage)
-  if response["result"]{"chats"} != nil:
+  if response{"result"}{"chats"} != nil:
     for jsonChat in response["result"]["chats"]:
       let chat = jsonChat.toChat
       self.channels[chat.id] = chat

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtQml.Models 2.13
 import QtGraphicalEffects 1.13
+import QtQuick.Dialogs 1.3
 import "../../../../shared"
 import "../../../../imports"
 import "../components"
@@ -132,6 +133,10 @@ ScrollView {
                 chatLogView.scrollToBottom(true)
             }
 
+            onSendingMessageFailed: {
+                sendingMsgFailedPopup.open();
+            }
+
             onNewMessagePushed: {
                 if (!chatLogView.scrollToBottom()) {
                     root.newMessages++
@@ -170,6 +175,13 @@ ScrollView {
         model: messageListDelegate
         section.property: "sectionIdentifier"
         section.criteria: ViewSection.FullString
+    }
+
+    MessageDialog {
+        id: sendingMsgFailedPopup
+        standardButtons: StandardButton.Ok
+        text: qsTr("Failed to send message.")
+        icon: StandardIcon.Critical
     }
 
     DelegateModel {


### PR DESCRIPTION
fix https://github.com/status-im/nim-status-client/issues/898

The segmentation fault occured because the RPC response returned json with an error message as opposed to the usual data required to update the chat. Since the section of the code didn't handle this error message it caused the app to crash. I've handled this error to show an error alert box by emitting a `sendMessageFailed` event

![block_user_crash](https://user-images.githubusercontent.com/58890963/100668625-e7954e00-3364-11eb-8425-a06441920a8a.gif)
