### PR TITLE
fix: check if user is blocked on profile popup

### DIFF
--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -123,6 +123,12 @@ QtObject:
     read = getBlockedContacts
     notify = contactListChanged
 
+  proc isContactBlocked*(self: ProfileView, pubkey: string): bool {.slot.} =
+    for contact in self.blockedContacts.contacts:
+      if contact.id == pubkey:
+        return true
+    return false
+
   proc isMnemonicBackedUp*(self: ProfileView): bool {.slot.} =
     let mnemonic = status_settings.getSetting[string](Setting.Mnemonic, "")
     return mnemonic == ""
@@ -337,9 +343,11 @@ QtObject:
     discard self.status.contacts.addContact(publicKey, nicknameToSet)
 
   proc unblockContact*(self: ProfileView, publicKey: string) {.slot.} =
+    self.contactListChanged()
     discard self.status.contacts.unblockContact(publicKey)
 
   proc blockContact*(self: ProfileView, publicKey: string): string {.slot.} =
+    self.contactListChanged()
     return self.status.contacts.blockContact(publicKey)
 
   proc removeContact*(self: ProfileView, publicKey: string) {.slot.} =

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -28,6 +28,8 @@ StackLayout {
         chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
     }
 
+    property bool isBlocked: Utils.isContactBlocked(chatsModel.activeChannel.id, profileModel.getBlockedContacts())
+
     Component.onCompleted: {
         chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
     }
@@ -236,6 +238,8 @@ StackLayout {
                     if (chatsModel.activeChannel.chatType !== Constants.chatTypePrivateGroupChat) return true;
                     return chatsModel.activeChannel.isMember
                 }
+                enabled: !isBlocked
+                chatInputPlaceholder: isBlocked ? qsTr("This user has been blocked.") : qsTr("Type a message.")
                 anchors.bottom: parent.bottom
                 recentStickers: chatsModel.recentStickers
                 stickerPackList: chatsModel.stickerPacks

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -74,7 +74,6 @@ StackLayout {
     Connections {
         target: profileModel
         onContactListChanged: {
-            console.log("Contact list changed");
             isBlocked = profileModel.isContactBlocked(chatsModel.activeChannel.id);
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -28,7 +28,8 @@ StackLayout {
         chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
     }
 
-    property bool isBlocked: Utils.isContactBlocked(chatsModel.activeChannel.id, profileModel.getBlockedContacts())
+    property bool isBlocked: profileModel.isContactBlocked(chatsModel.activeChannel.id)
+
 
     Component.onCompleted: {
         chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
@@ -70,6 +71,13 @@ StackLayout {
         txModalLoader.close()
     }
 
+    Connections {
+        target: profileModel
+        onContactListChanged: {
+            console.log("Contact list changed");
+            isBlocked = profileModel.isContactBlocked(chatsModel.activeChannel.id);
+        }
+    }
     
     ColumnLayout {
         spacing: 0
@@ -239,7 +247,9 @@ StackLayout {
                     return chatsModel.activeChannel.isMember
                 }
                 enabled: !isBlocked
-                chatInputPlaceholder: isBlocked ? qsTr("This user has been blocked.") : qsTr("Type a message.")
+                chatInputPlaceholder: isBlocked ?
+                        qsTr("This user has been blocked.") :
+                        qsTr("Type a message.")
                 anchors.bottom: parent.bottom
                 recentStickers: chatsModel.recentStickers
                 stickerPackList: chatsModel.stickerPacks

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -40,7 +40,7 @@ ModalPopup {
         identicon = identiconParam || ""
         text = textParam || ""
         isEnsVerified = chatsModel.isEnsVerified(this.fromAuthor)
-        isBlocked = Utils.isContactBlocked(this.fromAuthor, profileModel.getBlockedContacts());
+        isBlocked = profileModel.isContactBlocked(this.fromAuthor);
         alias = chatsModel.alias(this.fromAuthor) || ""
         
         showQR = false
@@ -392,7 +392,9 @@ ModalPopup {
             btnBorderWidth: 1
             btnBorderColor: Style.current.grey
             textColor: Style.current.red
-            label: isBlocked ? qsTr("Unblock User") : qsTr("Block User")
+            label: isBlocked ?
+                    qsTr("Unblock User") :
+                    qsTr("Block User")
             anchors.bottom: parent.bottom
             onClicked: {
                 if (isBlocked) {

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -197,13 +197,4 @@ QtObject {
             default: return network
         }
     }
-
-    function isContactBlocked(fromAuthor, blockedList) {
-        for (let i = 0; i < blockedList.rowCount(); i++) {
-            if (blockedList.rowData(i, 'pubKey') === fromAuthor) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -197,4 +197,13 @@ QtObject {
             default: return network
         }
     }
+
+    function isContactBlocked(fromAuthor, blockedList) {
+        for (let i = 0; i < blockedList.rowCount(); i++) {
+            if (blockedList.rowData(i, 'pubKey') === fromAuthor) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -32,6 +32,8 @@ Rectangle {
 
     property int chatType
 
+    property string chatInputPlaceholder: qsTr("Type a message")
+
     property alias textInput: messageInputField
 
     height: {
@@ -626,7 +628,7 @@ Rectangle {
                 wrapMode: TextArea.Wrap
                 anchors.bottom: parent.bottom
                 anchors.top: parent.top
-                placeholderText: qsTr("Type a message")
+                placeholderText: chatInputPlaceholder
                 placeholderTextColor: Style.current.secondaryText
                 selectByMouse: true
                 color: Style.current.textColor

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -32,7 +32,7 @@ Rectangle {
 
     property int chatType
 
-    property string chatInputPlaceholder: qsTr("Type a message")
+    property string chatInputPlaceholder: qsTr("Type a message.")
 
     property alias textInput: messageInputField
 


### PR DESCRIPTION
This PR is a response to @emizzle's suggested change in PR #1431 . It checks if a user is blocked before exposing certain functionality to the user in a Profile popup. 

I've also added functionality to the StatusChatInput component that checks whether the chat recipient has been blocked and disabling it if the latter is true. The caveat is that the update to the `profileModel's blocked list` doesn't get picked up by the current active chat window. It only gets picked up when you find some way to reload the chat component eg switching chats/changing nickname

![chat-inpout-blocked](https://user-images.githubusercontent.com/58890963/100876940-c3df1e80-34b0-11eb-8199-165a7e4b4b14.gif)


