### PR TITLE
fix: markdown leading whitespace

### DIFF
--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -337,7 +337,7 @@ Rectangle {
         if(control.isImage){
             chatsModel.sendImage(imageArea.imageSource);
         }
-        var msg = chatsModel.plainText(Emoji.deparse(messageInputField.text).trim()).trim()
+        var msg = chatsModel.plainText(Emoji.deparse(messageInputField.text))
         if(msg.length > 0){
             msg = interpretMessage(msg)
             chatsModel.sendMessage(msg, control.isReply ? SelectedMessage.messageId : "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType);


### PR DESCRIPTION
fixes #1376

the messages still get trimmed if you send a normal message with leading whitespace for example (or when there's too many whitespaces between 2 words)

![2020-12-06-033821_829x517_scrot](https://user-images.githubusercontent.com/58890963/101269196-c7a2c780-3774-11eb-9c5b-ffcab879bebc.png)
