### PR TITLE
fix: use ConfirmationDialog when unblocking users

### DIFF
--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -154,9 +154,10 @@ ModalPopup {
             }
         }
 
-        UnblockContactConfirmationDialog {
+        ConfirmationDialog {
             id: unblockContactConfirmationDialog
-            onUnblockButtonClicked: {
+            title: qsTr("Unblock user")
+            onConfirmButtonClicked: {
                 profileModel.unblockContact(fromAuthor)
                 unblockContactConfirmationDialog.close();
                 popup.close()
@@ -396,8 +397,6 @@ ModalPopup {
             anchors.bottom: parent.bottom
             onClicked: {
                 if (isBlocked) {
-                    unblockContactConfirmationDialog.contactName = userName;
-                    unblockContactConfirmationDialog.contactAddress = fromAuthor;
                     unblockContactConfirmationDialog.open();
                     return;
                 }


### PR DESCRIPTION
We've introduced a bug in https://github.com/status-im/nim-status-client/commit/8fd28dfa where a
non-existing `UnblockContactConfirmationDialog` usage was added.
This commit changes it to be a standard `ConfirmationDialog` to make the application compile
again.