### PR TITLE
fix(Chat): ensure image area is reset properly when removing images

### DIFF
--- a/ui/shared/status/StatusChatInputImageArea.qml
+++ b/ui/shared/status/StatusChatInputImageArea.qml
@@ -80,7 +80,7 @@ Rectangle {
         }
         onClicked: {
             imageArea.imageRemoved()                
-            chatImage.source = ""
+            imageArea.imageSource = ""
         }
         MouseArea {
             cursorShape: Qt.PointingHandCursor


### PR DESCRIPTION
We were only resetting the `Image` source but not the consumer facing `imageSource`
property when removing a selected image from the image area.

This cause the `imageSource` to practically never change after an image has
been selected the first time. Selecting an image another time would open the
image area, but if the image happens to be the same as the first time, the `imageSource`
practically didn't change, causing the app to render an "empty" image.