### PR TITLE
refactor(Chat): move suggestions ListModel into StatusChatInput

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -166,18 +166,14 @@ StackLayout {
             id: messageContextMenu
         }
  
-        ListModel {
-            id: suggestions
-        }
-
         Connections {
             target: chatsModel
             onActiveChannelChanged: {
                 chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
-                suggestions.clear()
+                chatInput.suggestionsList.clear()
                 const len = chatsModel.suggestionList.rowCount()
                 for (let i = 0; i < len; i++) {
-                    suggestions.append({
+                    chatInput.suggestionsList.append({
                                            alias: chatsModel.suggestionList.rowData(i, "alias"),
                                            ensName: chatsModel.suggestionList.rowData(i, "ensName"),
                                            address: chatsModel.suggestionList.rowData(i, "address"),

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -41,6 +41,8 @@ Rectangle {
     property var fileUrls: null
     property alias messageSound: sendMessageSound
 
+    property alias suggestionsList: suggestions
+
     height: {
         if (extendedArea.visible) {
             return messageInput.height + extendedArea.height + Style.current.bigPadding
@@ -366,6 +368,11 @@ Rectangle {
         replyArea.identicon = identicon
         messageInputField.forceActiveFocus();
     }
+
+    ListModel {
+        id: suggestions
+    }
+
 
     FileDialog {
         id: imageDialog


### PR DESCRIPTION
StatusChatInput was relying on the suggestions ListModel, even though there was
no guarantee that it would exist. This is more apparent when using the component
in different context (e.g. Timeline/Status Updates). QML will throw a reference
error in this case.