### PR TITLE
feat: make `UserNameLabel` render local nick names and ENS names

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -343,7 +343,7 @@ QtObject:
   proc pushMessages*(self:ChatsView, messages: var seq[Message]) =
     for msg in messages.mitems:
       self.upsertChannel(msg.chatId)
-      msg.alias = self.status.chat.getUserName(msg.fromAuthor, msg.alias)
+      msg.userName = self.status.chat.getUserName(msg.fromAuthor, msg.alias)
       self.messageList[msg.chatId].add(msg)
       self.messagePushed()
       if self.channelOpenTime.getOrDefault(msg.chatId, high(int64)) < msg.timestamp.parseFloat.fromUnixFloat.toUnix:

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -33,6 +33,8 @@ type
     EmojiReactions = UserRole + 22
     CommandParameters = UserRole + 23
     LinkUrls = UserRole + 24
+    Alias = UserRole + 25
+    LocalName = UserRole + 26
 
 QtObject:
   type
@@ -115,7 +117,7 @@ QtObject:
     let message = self.messages[index.row]
     let chatMessageRole = role.ChatMessageRoles
     case chatMessageRole:
-      of ChatMessageRoles.UserName: result = newQVariant(message.alias)
+      of ChatMessageRoles.UserName: result = newQVariant(message.userName)
       of ChatMessageRoles.Message: result = newQVariant(self.renderBlock(message))
       of ChatMessageRoles.PlainText: result = newQVariant(message.text)
       of ChatMessageRoles.Timestamp: result = newQVariant(message.timestamp)
@@ -149,6 +151,8 @@ QtObject:
         "commandState": message.commandParameters.commandState,
         "signature": message.commandParameters.signature
       }))
+      of ChatMessageRoles.Alias: result = newQVariant(message.alias)
+      of ChatMessageRoles.LocalName: result = newQVariant(message.localName)
 
   method roleNames(self: ChatMessageList): Table[int, string] =
     {
@@ -175,7 +179,9 @@ QtObject:
       ChatMessageRoles.AudioDurationMs.int: "audioDurationMs",
       ChatMessageRoles.EmojiReactions.int: "emojiReactions",
       ChatMessageRoles.LinkUrls.int: "linkUrls",
-      ChatMessageRoles.CommandParameters.int: "commandParameters"
+      ChatMessageRoles.CommandParameters.int: "commandParameters",
+      ChatMessageRoles.Alias.int:"alias",
+      ChatMessageRoles.LocalName.int:"localName"
     }.toTable
 
   proc getMessageIndex(self: ChatMessageList, messageId: string): int {.slot.} =
@@ -188,7 +194,9 @@ QtObject:
 
     let message = self.messages[index]
     case data:
-    of "userName": result = (message.alias)
+    of "userName": result = (message.userName)
+    of "alias": result = (message.alias)
+    of "localName": result = (message.localName)
     of "message": result = (message.text)
     of "identicon": result = (message.identicon)
     of "timestamp": result = $(message.timestamp)
@@ -246,6 +254,8 @@ QtObject:
     for c in contacts:
       for m in self.messages.mitems:
         if m.fromAuthor == c.id:
-          m.alias = userNameOrAlias(c)
+          m.userName = userNameOrAlias(c)
+          m.alias = c.alias
+          m.localName = c.localNickname
 
     self.dataChanged(topLeft, bottomRight, @[ChatMessageRoles.Username.int])

--- a/src/status/chat/message.nim
+++ b/src/status/chat/message.nim
@@ -31,6 +31,8 @@ type CommandParameters* = object
 
 type Message* = object
   alias*: string
+  userName*: string
+  localName*: string
   chatId*: string
   clock*: int
   commandParameters*: CommandParameters

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -171,6 +171,8 @@ proc toMessage*(jsonMsg: JsonNode): Message =
 
   var message = Message(
       alias: jsonMsg{"alias"}.getStr,
+      userName: "",
+      localName: "",
       chatId: jsonMsg{"localChatId"}.getStr,
       clock: jsonMsg{"clock"}.getInt,
       contentType: contentType,

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -166,18 +166,14 @@ StackLayout {
             id: messageContextMenu
         }
  
-        ListModel {
-            id: suggestions
-        }
-
         Connections {
             target: chatsModel
             onActiveChannelChanged: {
                 chatInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
-                suggestions.clear()
+                chatInput.suggestionsList.clear()
                 const len = chatsModel.suggestionList.rowCount()
                 for (let i = 0; i < len; i++) {
-                    suggestions.append({
+                    chatInput.suggestionsList.append({
                                            alias: chatsModel.suggestionList.rowData(i, "alias"),
                                            ensName: chatsModel.suggestionList.rowData(i, "ensName"),
                                            address: chatsModel.suggestionList.rowData(i, "address"),

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -238,6 +238,8 @@ ScrollView {
             fromAuthor: model.fromAuthor
             chatId: model.chatId
             userName: model.userName
+            alias: model.alias
+            localName: model.localName
             message: model.message
             plainText: model.plainText
             identicon: model.identicon

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -7,6 +7,8 @@ import "../components"
 Item {
     property string fromAuthor: "0x0011223344556677889910"
     property string userName: "Jotaro Kujo"
+    property string alias: ""
+    property string localName: ""
     property string message: "That's right. We're friends...  Of justice, that is."
     property string plainText: "That's right. We're friends...  Of justice, that is."
     property string identicon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQAQMAAAC6caSPAAAABlBMVEXMzMz////TjRV2AAAAAWJLR0QB/wIt3gAAACpJREFUGBntwYEAAAAAw6D7Uw/gCtUAAAAAAAAAAAAAAAAAAAAAAAAAgBNPsAABAjKCqQAAAABJRU5ErkJggg=="

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -56,7 +56,7 @@ Item {
         }
     }
 
-    function clickMessage(isProfileClick, isSticker = false, isImage = false, image = null) {
+    function clickMessage(isProfileClick, isSticker = false, isImage = false, image = null, emojiOnly = false) {
         if (isImage) {
             imageClick(image);
             return;
@@ -77,6 +77,7 @@ Item {
         }
         messageContextMenu.isProfile = !!isProfileClick
         messageContextMenu.isSticker = isSticker
+        messageContextMenu.emojiOnly = emojiOnly
         messageContextMenu.show(userName, fromAuthor, identicon, "", nickname)
         // Position the center of the menu where the mouse is
         messageContextMenu.x = messageContextMenu.x - messageContextMenu.width / 2

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -33,6 +33,9 @@ Item {
 //        anchors.top: dateGroupLbl.visible ? dateGroupLbl.bottom : parent.top
         anchors.top: parent.top
         anchors.left: chatImage.right
+        userName: messageItem.userName
+        localName: messageItem.localName
+        alias: messageItem.alias
     }
 
     ChatReply {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -32,6 +32,9 @@ Item {
         anchors.top: dateGroupLbl.visible ? dateGroupLbl.bottom : parent.top
         anchors.topMargin: 0
         anchors.left: chatImage.right
+        userName: messageItem.userName
+        localName: messageItem.localName
+        alias: messageItem.alias
     }
 
     Rectangle {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/UsernameLabel.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/UsernameLabel.qml
@@ -2,24 +2,62 @@ import QtQuick 2.3
 import "../../../../../shared"
 import "../../../../../imports"
 
-StyledTextEdit {
-    id: chatName
+Item {
+    id: root
+    height: childrenRect.height
+    width: chatName.width + ensOrAlias.width + ensOrAlias.anchors.leftMargin
+    property string userName: ""
+    property string localName: ""
+    property string alias: ""
+    property alias label: chatName
     visible: isMessage && authorCurrentMsg != authorPrevMsg
-    height: this.visible ? 18 : 0
-    //% "You"
-    text: !isCurrentUser ? Utils.removeStatusEns(userName) : qsTrId("You")
-    color: (userName.startsWith("@") || isCurrentUser) ? Style.current.blue : Style.current.textColor
-    font.bold: true
-    font.pixelSize: Style.current.secondaryTextFontSize
-    readOnly: true
-    wrapMode: Text.WordWrap
-    selectByMouse: true
-    MouseArea {
-        cursorShape: Qt.PointingHandCursor
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-        anchors.fill: parent
-        onClicked: {
-            clickMessage(true)
+
+    StyledTextEdit {
+        id: chatName
+        text: {
+            if (isCurrentUser) {
+                return qsTr("You")
+            }
+
+            if (root.localName !== "") {
+                return root.localName
+            }
+
+            if (root.userName !== "") {
+                return Utils.removeStatusEns(root.userName)
+            }
+            return Utils.removeStatusEns(root.alias)
         }
+        color: text.startsWith("@") || isCurrentUser || root.localName !== "" ? Style.current.blue : Style.current.secondaryText
+        font.weight: Font.Medium
+        font.pixelSize: Style.current.secondaryTextFontSize
+        readOnly: true
+        wrapMode: Text.WordWrap
+        selectByMouse: true
+        MouseArea {
+            cursorShape: Qt.PointingHandCursor
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            anchors.fill: parent
+            hoverEnabled: true
+            onEntered: {
+                parent.font.underline = true
+            }
+            onExited: {
+                parent.font.underline = false
+            }
+            onClicked: {
+                clickMessage(true)
+            }
+        }
+    }
+
+    StyledText {
+        id: ensOrAlias
+        visible: root.localName !== "" && root.userName.startsWith("@")
+        text: root.userName
+        color: Style.current.secondaryText
+        font.pixelSize: chatName.font.pixelSize
+        anchors.left: chatName.right
+        anchors.leftMargin: chatName.visible ? 4 : 0
     }
 }

--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -10,6 +10,7 @@ import "./"
 PopupMenu {
     property bool isProfile: false
     property bool isSticker: false
+    property bool emojiOnly: false
 
     id: messageContextMenu
     width: messageContextMenu.isProfile ? profileHeader.width : emojiContainer.width
@@ -31,7 +32,7 @@ PopupMenu {
 
     Item {
         id: emojiContainer
-        visible: !messageContextMenu.isProfile
+        visible: messageContextMenu.emojiOnly || !messageContextMenu.isProfile
         width: emojiRow.width
         height: visible ? emojiRow.height : 0
 
@@ -40,7 +41,7 @@ PopupMenu {
             spacing: Style.current.smallPadding
             leftPadding: Style.current.smallPadding
             rightPadding: Style.current.smallPadding
-            bottomPadding: Style.current.padding
+            bottomPadding: messageContextMenu.emojiOnly ? 0 : Style.current.padding
 
             Repeater {
                 model: reactionModel
@@ -106,6 +107,7 @@ PopupMenu {
 
     Separator {
         anchors.bottom: viewProfileAction.top
+        visible: !messageContextMenu.emojiOnly
     }
 
     Action {
@@ -119,6 +121,7 @@ PopupMenu {
         icon.source: "../../../img/profileActive.svg"
         icon.width: 16
         icon.height: 16
+        enabled: !emojiOnly
     }
     Action {
         text: messageContextMenu.isProfile ?
@@ -133,6 +136,6 @@ PopupMenu {
         icon.source: "../../../img/messageActive.svg"
         icon.width: 16
         icon.height: 16
-        enabled: !isSticker
+        enabled: !isSticker && !emojiOnly
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/List.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/List.qml
@@ -259,8 +259,8 @@ Item {
 
         UsernameLabel {
             id: chatName
-            text: "@" + (profileModel.ens.preferredUsername.replace(".stateofus.eth", ""))
-            color: Style.current.blue
+            label.text: "@" + (profileModel.ens.preferredUsername.replace(".stateofus.eth", ""))
+            label.color: Style.current.blue
             anchors.leftMargin: 20
             anchors.top: parent.top
             anchors.topMargin: 0

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -41,6 +41,8 @@ Rectangle {
     property var fileUrls: null
     property alias messageSound: sendMessageSound
 
+    property alias suggestionsList: suggestions
+
     height: {
         if (extendedArea.visible) {
             return messageInput.height + extendedArea.height + Style.current.bigPadding
@@ -366,6 +368,11 @@ Rectangle {
         replyArea.identicon = identicon
         messageInputField.forceActiveFocus();
     }
+
+    ListModel {
+        id: suggestions
+    }
+
 
     FileDialog {
         id: imageDialog


### PR DESCRIPTION
In timeline status update messages we want to render the ENS name next to a
local nickname in case it exists. This commit extends the `UsernameLabel` to do
just that.

Closes #1488

Couple of things are happening here:

- Prior to this commit, in QML we had `message.userName` which was reading from the Nim's `message.alias` counterpart.
- This means, in QML, `message.userName` could've been either the user's the word alias, its ENS name, or its local nickname
- We need all of them in `UserNameLabel` to implement the design for the status updates timeline so this commit introduces two new properites to the QML object: `localName` and `alias`
- Now, just like the names intend, `localName` is always `contact.localNickName`. `alias` is always `contact.alias` and `userName` stays what it was before (still one of the three options)
- Having those properties, we can pass them down to `UsernameLabel` and calculate its text based on some heuristics.