### PR TITLE
feat: add OS notification and setting to switch back

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/NotificationsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/NotificationsContainer.qml
@@ -160,6 +160,34 @@ ScrollView {
                 }
             }
 
+            RowLayout {
+                width: parent.width
+                StyledText {
+                    text: qsTr("Use your operating system's notifications")
+                    font.pixelSize: 15
+                    wrapMode: Text.WordWrap
+                    Layout.fillWidth: true
+
+                    StyledText {
+                        id: detailText
+                        text: qsTr("Setting this to false will instead use Status' notification style as seen below")
+                        color: Style.current.secondaryText
+                        width: parent.width
+                        font.pixelSize: 12
+                        wrapMode: Text.WordWrap
+                        anchors.top: parent.bottom
+                    }
+                }
+
+                StatusSwitch {
+                    Layout.alignment: Qt.AlignRight
+                    checked: appSettings.useOSNotifications
+                    onCheckedChanged: {
+                        appSettings.useOSNotifications = checked
+                    }
+                }
+            }
+
             /* GridLayout { */
             /*     columns: 4 */
             /*     width: parent.width */

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -15,6 +15,8 @@ QtObject {
     readonly property int limitLongChatText: 500
     readonly property int limitLongChatTextCompactMode: 1000
 
+    readonly property int notificationPopupTTL: 5000
+
     readonly property string chat: "chat"
     readonly property string wallet: "wallet"
     readonly property string browser: "browser"

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -102,6 +102,7 @@ ApplicationWindow {
         property real volume: 0.2
         property int notificationSetting: Constants.notifyAllMessages
         property bool notificationSoundsEnabled: true
+        property bool useOSNotifications: true
         property int notificationMessagePreviewSetting: Constants.notificationPreviewNameAndMessage
         property bool allowNotificationsFromNonContacts: false
         property var whitelistedUnfurlingSites: ({})
@@ -139,6 +140,7 @@ ApplicationWindow {
         property real volume: defaultAppSettings.volume
         property int notificationSetting: defaultAppSettings.notificationSetting
         property bool notificationSoundsEnabled: defaultAppSettings.notificationSoundsEnabled
+        property bool useOSNotifications: defaultAppSettings.useOSNotifications
         property int notificationMessagePreviewSetting: defaultAppSettings.notificationMessagePreviewSetting
         property bool allowNotificationsFromNonContacts: defaultAppSettings.allowNotificationsFromNonContacts
         property var whitelistedUnfurlingSites: defaultAppSettings.whitelistedUnfurlingSites
@@ -178,6 +180,7 @@ ApplicationWindow {
     }
 
     SystemTrayIcon {
+        id: systemTray
         visible: true
         icon.source: "shared/img/status-logo.png"
         menu: Menu {


### PR DESCRIPTION
Fixes #1423 

Adds OS notifications, meaning notifications that use your OS' notification tray.

Adds a setting in Notifications as well to switch back to the old "Status notifications"

I also fixed the Timer issue we had where the Status Notification never went away.

Known issues:
- In Linux, clicking the notification just closes it without calling `onClick`. Not sure if there is much we can do about it
- In Linux, the notification doesn't disappear after the timer
- the icon is not changeable to anything that is useful. I tried using `NoIcon`, but it ddoesn't work both on lInux and Windows, so we're stuck with the `Info` icon. The other options are `Wanring` and `Danger` which are obviously worse.

![image](https://user-images.githubusercontent.com/11926403/101514778-a6480400-394b-11eb-9c4c-6dc64ea4b23e.png)
