### PR TITLE
refactor: in Windows packaged build fleets.json should be in resources/

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -22,7 +22,13 @@ logScope:
   topics = "main"
 
 proc mainProc() =
-  let status = statuslib.newStatusInstance(readFile(joinPath(getAppDir(), "../fleets.json")))
+  let fleets =
+    if defined(windows) and getEnv("NIM_STATUS_CLIENT_DEV").string == "":
+      "/../resources/fleets.json"
+    else:
+      "/../fleets.json"
+
+  let status = statuslib.newStatusInstance(readFile(joinPath(getAppDir(), fleets)))
   status.initNode()
 
   enableHDPI()


### PR DESCRIPTION
In the context of Windows packaged builds, this is consistent with other resources needed by the application; organizing them in this way keeps the top-level directory of Windows packaged builds clear of files that most users should never have to see or think about.

---

See: https://github.com/status-im/nim-status-client/pull/1412#issuecomment-736779309.