### PR TITLE
fix: chat reply width when content is smaller than author

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
@@ -1,9 +1,11 @@
-import QtQuick 2.3
+import QtQuick 2.14
 import "../../../../../shared"
 import "../../../../../imports"
 
 Loader {
     property int textFieldWidth: item ? item.textField.width : 0
+    property int authorWidth: item ? item.authorMetrics.width : 0
+
     property bool longReply: false
     property color elementsColor: isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText
 
@@ -13,12 +15,19 @@ Loader {
     sourceComponent: Component {
         Rectangle {
             property alias textField: lblReplyMessage
+            property alias authorMetrics: txtAuthorMetrics
 
             id: chatReply
             visible: responseTo != "" && replyMessageIndex > -1
             // childrenRect.height shows a binding loop for soem reason, so we use heights instead
             height: this.visible ? lblReplyAuthor.height + ((repliedMessageType === Constants.imageType ? imgReplyImage.height : lblReplyMessage.height) + 5 + 8) : 0
             color: Style.current.transparent
+
+            TextMetrics {
+                id: txtAuthorMetrics
+                font: lblReplyAuthor.font
+                text: lblReplyAuthor.text
+            }
 
             StyledTextEdit {
                 id: lblReplyAuthor

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -95,6 +95,13 @@ Item {
                     if (chatReply.visible && chatText.width < chatReply.textFieldWidth) {
                         baseWidth = chatReply.textFieldWidth
                     }
+
+                    if (chatReply.visible && chatText.width < chatReply.authorWidth) {
+                        if(chatReply.authorWidth > baseWidth){
+                            baseWidth = chatReply.authorWidth + 20
+                        }
+                    }
+
                     return baseWidth + 2 * chatHorizontalPadding
             }
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1106587/101829330-3b442c00-3b09-11eb-88ce-a137cbcc6c2b.png)

After:
![image](https://user-images.githubusercontent.com/1106587/101829235-18b21300-3b09-11eb-884f-d223ae52f565.png)
