### PR TITLE
chore: re-add sticker loading UI

### DIFF
--- a/src/app/chat/views/stickers.nim
+++ b/src/app/chat/views/stickers.nim
@@ -100,10 +100,10 @@ QtObject:
     self.stickerPacksLoaded()
     self.installedStickerPacksUpdated()
 
-  proc getNumInstalledStickerPacks(self: StickersView): QVariant {.slot.} =
-    newQVariant(self.status.stickers.installedStickerPacks.len)
+  proc getNumInstalledStickerPacks(self: StickersView): int {.slot.} =
+    self.status.stickers.installedStickerPacks.len
 
-  QtProperty[QVariant] numInstalledStickerPacks:
+  QtProperty[int] numInstalledStickerPacks:
     read = getNumInstalledStickerPacks
     notify = installedStickerPacksUpdated
 

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -486,7 +486,6 @@ Rectangle {
         onStickerSelected: {
             control.stickerSelected(hashId, packId)
             messageInputField.forceActiveFocus();
-            stickersPopup.close()
         }
         onClosed: {
             stickersBtn.highlighted = false

--- a/ui/shared/status/StatusStickerList.qml
+++ b/ui/shared/status/StatusStickerList.qml
@@ -22,19 +22,12 @@ GridView {
             anchors.fill: parent
             anchors.topMargin: 4
             anchors.leftMargin: 4
-            Image {
+            ImageLoader {
                 width: 80
                 height: 80
-                sourceSize.width: width
-                sourceSize.height: height
-                fillMode: Image.PreserveAspectFit
                 source: "https://ipfs.infura.io/ipfs/" + url
-                MouseArea {
-                    cursorShape: Qt.PointingHandCursor
-                    anchors.fill: parent
-                    onClicked: {
-                        root.stickerClicked(hash, packId)
-                    }
+                onClicked: {
+                    root.stickerClicked(hash, packId)
                 }
             }
         }


### PR DESCRIPTION
Fixes #1284.
Fixes #1529. 

The sticker loading UI was removed when the StatusChatInput and friends were added in. This PR re-adds the sticker loading UI introduced in PR# 955 (https://github.com/status-im/nim-status-client/pull/955).