### PR TITLE
fix: channel/communities listview height depending on search string

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
@@ -10,16 +10,13 @@ Item {
     property string searchStr: ""
     id: root
     width: parent.width
-    height: childrenRect.height
-    visible: communityListView.visible
-
+    height: Math.max(communityListView.height, noSearchResults.height)
     ListView {
         id: communityListView
         spacing: Style.current.halfPadding
         anchors.top: parent.top
         height: childrenRect.height
-        // FIXME the height doesn't update
-//        visible: height > 0
+        visible: height > 10
         width:parent.width
         interactive: false
         model: chatsModel.joinedCommunities

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -34,7 +34,7 @@ Rectangle {
     // Hide the box if it is filtered out
     property bool isVisible: searchStr == "" || name.includes(searchStr)
     visible: isVisible ? true : false
-    height: isVisible ? !isCompact ? 64 : contactImage.height + Style.current.smallPadding * 2 : 0
+    height: isVisible ? (!isCompact ? 64 : contactImage.height + Style.current.smallPadding * 2) : 0
 
     StatusIdenticon {
         id: contactImage

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
@@ -23,7 +23,7 @@ Rectangle {
         spacing: Style.current.halfPadding
         anchors.top: parent.top
         height: childrenRect.height
-        visible: height > 0
+        visible: height > 50
         anchors.right: parent.right
         anchors.left: parent.left
         interactive: false


### PR DESCRIPTION
I had to use some magic numbers because even if the height of the listview elements is 0, there's still some contentHeight  ¯\\\_(ツ)_/¯