### PR TITLE
fix: restore z-index to root Item of ChatText.qml

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -12,6 +12,7 @@ Item {
 
     id: root
     visible: contentType == Constants.messageType || isEmoji
+    z: 51
 
     height: visible ? (showMoreLoader.active ? childrenRect.height - 10 : chatText.height) : 0
 


### PR DESCRIPTION
This restores URL click-ability and selecting/copying text in chats.