### PR TITLE
fix: fix scroll going back down when hitting images

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -208,13 +208,15 @@ Item {
             imageUrls: root.imageUrls
             isCurrentUser: root.isCurrentUser
             contentType: root.contentType
+            container: root
         }
     }
 
     Component {
         id: statusUpdateComponent
         StatusUpdate {
-            clickMessage: messageItem.clickMessage
+            clickMessage: root.clickMessage
+            container: root
         }
     }
 
@@ -226,6 +228,7 @@ Item {
             linkUrls: root.linkUrls
             imageUrls: root.imageUrls
             contentType: root.contentType
+            container: root
         }
     }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatReply.qml
@@ -8,6 +8,7 @@ Loader {
 
     property bool longReply: false
     property color elementsColor: isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText
+    property var container
 
     id: root
     active: responseTo != "" && replyMessageIndex > -1
@@ -49,6 +50,7 @@ Loader {
                 anchors.topMargin: 5
                 anchors.left: parent.left
                 chatHorizontalPadding: 0
+                container: root.container
             }
 
             StyledTextEdit {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -10,6 +10,7 @@ Item {
     property bool showImages: appSettings.displayChatImages && root.imageUrls != ""
     property string linkUrls: ""
     property int contentType: 2
+    property var container
 
     id: root
     anchors.top: parent.top
@@ -47,6 +48,7 @@ Item {
         anchors.leftMargin: root.chatHorizontalPadding
         anchors.right: parent.right
         anchors.rightMargin: root.chatHorizontalPadding
+        container: root.container
     }
 
     ChatText {
@@ -72,6 +74,7 @@ Item {
                 imageSource: image
                 imageWidth: 200
                 onClicked: root.clickMessage(false, false, true, image)
+                container: root.container
             }
         }
     }
@@ -100,7 +103,7 @@ Item {
                     anchors.left: parent.left
                     anchors.leftMargin: root.chatVerticalPadding
                     contentType: root.contentType
-                    container: root.parent
+                    container: root.container
                 }
             }
         }
@@ -148,7 +151,7 @@ Item {
                 onClicked: {
                     root.clickMessage(false, false, true, image)
                 }
-                container: root.parent
+                container: root.container
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageLoader.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageLoader.qml
@@ -62,7 +62,7 @@ Item {
                 imageMessage.visible = false
             } else if (imageMessage.status === Image.Ready) {
                 loadingImage.visible = false
-                scrollToBottom(true, root.container)
+                scrollToBottom(true, imageContainer.container)
             }
         }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ImageMessage.qml
@@ -51,7 +51,7 @@ Rectangle {
             onClicked: {
                 imageChatBox.clicked(image)
             }
-            container: root.container
+            container: imageChatBox.container
         }
     }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -9,6 +9,7 @@ Item {
     property string linkUrls: ""
     property bool isCurrentUser: false
     property int contentType: 2
+    property var container
 
     id: root
     anchors.top: parent.top
@@ -125,6 +126,7 @@ Item {
             anchors.leftMargin: Style.current.padding
             anchors.right: parent.right
             anchors.rightMargin: chatBox.chatHorizontalPadding
+            container: root.container
         }
 
         ChatText {
@@ -165,6 +167,7 @@ Item {
                         imageWidth: 250
                         isCurrentUser: root.isCurrentUser
                         onClicked: root.clickMessage(false, false, true, image)
+                        container: root.container
                     }
                 }
             }
@@ -191,7 +194,7 @@ Item {
             anchors.top: parent.top
             anchors.topMargin: chatBox.chatVerticalPadding
             color: Style.current.transparent
-            container: root.parent
+            container: root.container
             contentType: root.contentType
         }
 
@@ -247,7 +250,7 @@ Item {
         id: imageComponent
         ImageMessage {
             isCurrentUser: root.isCurrentUser
-            container: root.parent
+            container: root.container
             imageUrls: root.imageUrls
             onClicked: {
                 root.clickMessage(false, false, true, image)

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -15,6 +15,7 @@ Rectangle {
     radius: Style.current.radius
     color: hovered ? Style.current.border : Style.current.background
     property bool hovered: false
+    property var container
 
     UserImage {
         id: chatImage
@@ -66,6 +67,7 @@ Rectangle {
                 imageSource: image
                 imageWidth: 200
                 onClicked: root.clickMessage(false, false, true, image)
+                container: root.container
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/Sticker.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/Sticker.qml
@@ -13,9 +13,7 @@ Loader {
     sourceComponent: Component {
         Shared.ImageLoader {
             color: root.color
-            onLoaded: {
-                scrollToBottom(true, root.container)
-            }
+            onLoaded: scrollToBottom(true, root.container)
 
             width: 140
             height: this.visible ? 140 : 0


### PR DESCRIPTION
The problem was that the Image didn't receive the `container` (which is Message) correctly, so the mechanism to remember if an image already loaded didn't work