### PR TITLE
feat: introduce getAllContacts and getAddedContacts APIs

### DIFF
--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -1,4 +1,4 @@
-import json, sequtils
+import json, sequtils, sugar
 import libstatus/contacts as status_contacts
 import libstatus/accounts as status_accounts
 import profile/profile
@@ -39,8 +39,14 @@ proc unblockContact*(self: ContactModel, id: string): string =
   discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries,contact.alias, contact.identicon, contact.systemTags, contact.localNickname)
   self.events.emit("contactUnblocked", Args())
 
-proc getContacts*(self: ContactModel): seq[Profile] =
+proc getAllContacts*(): seq[Profile] =
   result = map(status_contacts.getContacts().getElems(), proc(x: JsonNode): Profile = x.toProfileModel())
+
+proc getAddedContacts*(): seq[Profile] =
+  result = getAllContacts().filter(c => c.systemTags.contains(":contact/added"))
+
+proc getContacts*(self: ContactModel): seq[Profile] =
+  result = getAllContacts()
   self.events.emit("contactUpdate", ContactUpdateArgs(contacts: result))
 
 proc addContact*(self: ContactModel, id: string, localNickname: string): string =


### PR DESCRIPTION
Primary motivator here was that the current `getContacts` APIs requries
a `ContactModel` which isn't always around. In fact, there's actually
no particular reason this APIs has to live on a model object.

However, to not break existing APIs I'm introducing a `getAllContacts`
API that returns all contacts as profiles, just like `contacts.getContacts`
does, without it being dependent on a `ContactModel`.

The same function is then used to add an API for returning all *added*
contacts as profiles.