### PR TITLE
feat: make saveChat API more flexible by taking a ChatType

### DIFF
--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -94,7 +94,7 @@ proc join*(self: ChatModel, chatId: string, chatType: ChatType, ensName: string 
 
   var chat = newChat(chatId, ChatType(chatType))
   self.channels[chat.id] = chat
-  status_chat.saveChat(chatId, chatType.isOneToOne, true, chat.color, ensName)
+  status_chat.saveChat(chatId, chatType, true, chat.color, ensName)
   if ensName != "":
     chat.name = ensName
     chat.ensName = ensName

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -1,4 +1,4 @@
-import json, sequtils
+import json, sequtils, sugar
 import libstatus/contacts as status_contacts
 import libstatus/accounts as status_accounts
 import profile/profile
@@ -39,8 +39,14 @@ proc unblockContact*(self: ContactModel, id: string): string =
   discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries,contact.alias, contact.identicon, contact.systemTags, contact.localNickname)
   self.events.emit("contactUnblocked", Args())
 
-proc getContacts*(self: ContactModel): seq[Profile] =
+proc getAllContacts*(): seq[Profile] =
   result = map(status_contacts.getContacts().getElems(), proc(x: JsonNode): Profile = x.toProfileModel())
+
+proc getAddedContacts*(): seq[Profile] =
+  result = getAllContacts().filter(c => c.systemTags.contains(":contact/added"))
+
+proc getContacts*(self: ContactModel): seq[Profile] =
+  result = getAllContacts()
   self.events.emit("contactUpdate", ContactUpdateArgs(contacts: result))
 
 proc addContact*(self: ContactModel, id: string, localNickname: string): string =

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -18,7 +18,7 @@ proc removeFilters*(chatId: string, filterId: string) =
     [{ "ChatID": chatId, "FilterID": filterId }]
   ])
 
-proc saveChat*(chatId: string, oneToOne: bool = false, active: bool = true, color: string, ensName: string = "") =
+proc saveChat*(chatId: string, chatType: ChatType, active: bool = true, color: string, ensName: string = "", profile: string = "") =
   # TODO: ideally status-go/stimbus should handle some of these fields instead of having the client
   # send them: lastMessage, unviewedMEssagesCount, timestamp, lastClockValue, name?
   discard callPrivateRPC("saveChat".prefix, %* [
@@ -28,9 +28,10 @@ proc saveChat*(chatId: string, oneToOne: bool = false, active: bool = true, colo
       "name": (if ensName != "": ensName else: chatId),
       "lastMessage": nil, # TODO:
       "active": active,
+      "profile": profile,
       "id": chatId,
       "unviewedMessagesCount": 0, # TODO:
-      "chatType":  if oneToOne: 1 else: 2,  # TODO: use constants
+      "chatType":  chatType.int,
       "timestamp": 1588940692659  # TODO:
     }
   ])


### PR DESCRIPTION
Previously, this API would take a flag `oneToOne` and would use it to determine
whether the chat type is going to be `1` or `2`. However, there are many more chat
types, so it's important this API supports all of them.

Since we already have an enum in place, I'm changing this function to take it instead.

In addition, it also gets a `profile` parameter which is needed to implement
the status timeline functionality.