### PR TITLE
fix(StatusUpdate): ensure hover effect is working properly

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -51,6 +51,20 @@ Rectangle {
         anchors.leftMargin: Style.current.halfPadding
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+                mouse.accepted = false
+            }
+            onEntered: {
+                root.hovered = true
+            }
+            onExited: {
+                root.hovered = false
+            }
+        }
     }
 
     Loader {
@@ -74,14 +88,15 @@ Rectangle {
         anchors.fill: parent
         hoverEnabled: true
         propagateComposedEvents: true
-        onClicked: {
-            mouse.accepted = false
-        }
         onEntered: {
-            root.hovered = true
+            if (!root.hovered) {
+                root.hovered = true
+            }
         }
         onExited: {
-            root.hovered = false
+            if (root.hovered) {
+              root.hovered = false
+            }
         }
     }
 
@@ -110,7 +125,7 @@ Rectangle {
             }
             onExited: {
                 if (root.hovered) {
-                  root.hovered = false
+                    root.hovered = false
                 }
             }
         }


### PR DESCRIPTION
This commit introduces some `MouseArea`s so components inside the
`StatusUpdate` component cancel it out by having a higher `z`.

Also, in some cases we need to conditionally set the `root.hovered` property
to ensure the values get inverted correctly, otherwise it causes undesired
flicker effects.