### PR TITLE
fix(StatusChatInput): ensure send button is disabled when message lim…

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -51,6 +51,20 @@ Rectangle {
         anchors.leftMargin: Style.current.halfPadding
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+                mouse.accepted = false
+            }
+            onEntered: {
+                root.hovered = true
+            }
+            onExited: {
+                root.hovered = false
+            }
+        }
     }
 
     Loader {
@@ -74,14 +88,15 @@ Rectangle {
         anchors.fill: parent
         hoverEnabled: true
         propagateComposedEvents: true
-        onClicked: {
-            mouse.accepted = false
-        }
         onEntered: {
-            root.hovered = true
+            if (!root.hovered) {
+                root.hovered = true
+            }
         }
         onExited: {
-            root.hovered = false
+            if (root.hovered) {
+              root.hovered = false
+            }
         }
     }
 
@@ -110,7 +125,7 @@ Rectangle {
             }
             onExited: {
                 if (root.hovered) {
-                  root.hovered = false
+                    root.hovered = false
                 }
             }
         }

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -749,8 +749,12 @@ Rectangle {
                 anchors.rightMargin: Style.current.halfPadding
                 anchors.bottom: parent.bottom
                 visible: imageBtn2.visible
-                highlighted: chatsModel.plainText(Emoji.deparse(messageInputField.text).trim()).trim().length > 0 || isImage
-                enabled: highlighted
+                highlighted: chatsModel.plainText(Emoji.deparse(messageInputField.text)).length > 0 || isImage
+                enabled: highlighted && messageInputField.length < messageLimit
+                onClicked: function (event) {
+                    control.sendMessage(event)
+                    control.hideExtendedArea();
+                }
             }
 
             StatusIconButton {


### PR DESCRIPTION
…it is exceeded

This was missing in the previous work we've done to make the `StatusChatInput` work
as a status timeline update component.

This commit also adds an event handler which was missing to trigger the `onMessage`
event when the send button is clicked.