### PR TITLE
feat: introduce isStatusUpdate flag in sendMessage APIs

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -4,6 +4,7 @@ import ../../status/mailservers as mailserver_model
 import ../../status/messages as messages_model
 import ../../status/signals/types
 import ../../status/libstatus/types as status_types
+import ../../status/libstatus/settings as status_settings
 import ../../status/[chat, contacts, status, wallet, stickers]
 import view, views/channels_list, views/message_list, views/reactions, views/stickers as stickers_view
 import ../../eventemitter
@@ -34,8 +35,11 @@ proc init*(self: ChatController) =
   self.handleChatEvents()
   self.handleSignals()
 
+  let pubKey = status_settings.getSetting[string](Setting.PublicKey, "0x0")
+
+  self.view.pubKey = pubKey
   self.status.mailservers.init()
-  self.status.chat.init()
+  self.status.chat.init(pubKey)
   self.status.stickers.init()
   self.view.reactions.init()
 

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -125,8 +125,8 @@ proc updateContacts*(self: ChatModel, contacts: seq[Profile]) =
     self.contacts[c.id] = c
   self.events.emit("chatUpdate", ChatUpdateArgs(contacts: contacts))
 
-proc init*(self: ChatModel) =
-  let chatList = status_chat.loadChats()
+proc init*(self: ChatModel, pubKey: string) =
+  var chatList = status_chat.loadChats()
 
   var filters:seq[JsonNode] = @[]
   for chat in chatList:

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -51,6 +51,20 @@ Rectangle {
         anchors.leftMargin: Style.current.halfPadding
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+                mouse.accepted = false
+            }
+            onEntered: {
+                root.hovered = true
+            }
+            onExited: {
+                root.hovered = false
+            }
+        }
     }
 
     Loader {
@@ -74,14 +88,15 @@ Rectangle {
         anchors.fill: parent
         hoverEnabled: true
         propagateComposedEvents: true
-        onClicked: {
-            mouse.accepted = false
-        }
         onEntered: {
-            root.hovered = true
+            if (!root.hovered) {
+                root.hovered = true
+            }
         }
         onExited: {
-            root.hovered = false
+            if (root.hovered) {
+              root.hovered = false
+            }
         }
     }
 
@@ -110,7 +125,7 @@ Rectangle {
             }
             onExited: {
                 if (root.hovered) {
-                  root.hovered = false
+                    root.hovered = false
                 }
             }
         }

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -749,8 +749,12 @@ Rectangle {
                 anchors.rightMargin: Style.current.halfPadding
                 anchors.bottom: parent.bottom
                 visible: imageBtn2.visible
-                highlighted: chatsModel.plainText(Emoji.deparse(messageInputField.text).trim()).trim().length > 0 || isImage
-                enabled: highlighted
+                highlighted: chatsModel.plainText(Emoji.deparse(messageInputField.text)).length > 0 || isImage
+                enabled: highlighted && messageInputField.length < messageLimit
+                onClicked: function (event) {
+                    control.sendMessage(event)
+                    control.hideExtendedArea();
+                }
             }
 
             StatusIconButton {


### PR DESCRIPTION
When sending a profile status update, the message has to be sent to
a specific channel that has the id `@PUBKEY`.

This commit introduces a flag that controls whether the message is
sent to the currently active channel, or tot he profile status channel.

The same is done for the `sendImage` API.