### PR TITLE
fix: introduce chat types for Timeline and Profile

### DIFF
--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -5,7 +5,9 @@ type ChatType* {.pure.}= enum
   Unknown = 0,
   OneToOne = 1, 
   Public = 2,
-  PrivateGroupChat = 3
+  PrivateGroupChat = 3,
+  Profile = 4,
+  Timeline = 5
 
 proc isOneToOne*(self: ChatType): bool = self == ChatType.OneToOne
 

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -109,13 +109,17 @@ proc newChat*(id: string, chatType: ChatType): Chat =
     result.name = id
 
 proc toChat*(jsonChat: JsonNode): Chat =
+
+  let chatTypeInt = jsonChat{"chatType"}.getInt
+  let chatType: ChatType = if chatTypeInt >= ord(low(ChatType)) or chatTypeInt <= ord(high(ChatType)): ChatType(chatTypeInt) else: ChatType.Unknown
+
   result = Chat(
     id: jsonChat{"id"}.getStr,
     name: jsonChat{"name"}.getStr,
     identicon: "",
     color: jsonChat{"color"}.getStr,
     isActive: jsonChat{"active"}.getBool,
-    chatType: ChatType(jsonChat{"chatType"}.getInt),
+    chatType: chatType,
     timestamp: jsonChat{"timestamp"}.getBiggestInt,
     lastClockValue: jsonChat{"lastClockValue"}.getBiggestInt,
     deletedAtClockValue: jsonChat{"deletedAtClockValue"}.getBiggestInt, 


### PR DESCRIPTION
When dealing with Timeline and Profile chat data, the `HEAD~1` would break
because we're trying to access `ChatType(4)` inside our `toChat` API.

To fix this issue, we have to make `ChatType` aware of `4` and `5` which are
`Profile` and `Timeline` respectively.