### PR TITLE
refactor: move getProfileImage API to appMain

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -57,14 +57,14 @@ Item {
     }
     property bool useLargeImage: contentType === Constants.chatIdentifier
 
-    property string profileImageSource: !placeholderMessage && chatView.getProfileImage(userPubKey, isCurrentUser, useLargeImage) || ""
+    property string profileImageSource: !placeholderMessage && appMain.getProfileImage(userPubKey, isCurrentUser, useLargeImage) || ""
 
     Connections {
         enabled: !placeholderMessage
         target: profileModel.contacts.list
         onContactChanged: {
             if (pubkey === fromAuthor) {
-                profileImageSource = chatView.getProfileImage(userPubKey, isCurrentUser, useLargeImage)
+                profileImageSource = appMain.getProfileImage(userPubKey, isCurrentUser, useLargeImage)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -50,7 +50,7 @@ Item {
 
             if (link.startsWith('//')) {
                 let pk = link.replace("//", "");
-                const userProfileImage = chatView.getProfileImage(pk)
+                const userProfileImage = appMain.getProfileImage(pk)
                 openProfilePopup(chatsModel.userNameOrAlias(pk), pk, userProfileImage || utilsModel.generateIdenticon(pk))
                 return;
             }

--- a/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
@@ -40,7 +40,7 @@ Rectangle {
                         groupInfoPopup.open()
                         break;
                     case Constants.chatTypeOneToOne:
-                        const profileImage = chatView.getProfileImage(chatsModel.activeChannel.id)
+                        const profileImage = appMain.getProfileImage(chatsModel.activeChannel.id)
                         openProfilePopup(chatsModel.activeChannel.name, chatsModel.activeChannel.id, profileImage || chatsModel.activeChannel.identicon)
                         break;
                 }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -37,19 +37,6 @@ SplitView {
         chatGroupsListViewCount: contactsColumn.chatGroupsListViewCount
     }
 
-    function getProfileImage(pubkey, isCurrentUser, useLargeImage) {
-        if (isCurrentUser || (isCurrentUser === undefined && pubkey === profileModel.profile.pubKey)) {
-            return profileModel.profile.thumbnailImage
-        }
-
-        const index = profileModel.contacts.list.getContactIndexByPubkey(pubkey)
-        if (index === -1) {
-            return
-        }
-
-        return profileModel.contacts.list.rowData(index, useLargeImage ? "largeImage" : "thumbnailImage")
-    }
-
     function openProfilePopup(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam, parentPopup){
         var popup = profilePopupComponent.createObject(chatView);
         if(parentPopup){

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -20,14 +20,14 @@ Rectangle {
     property bool muted: false
     property bool hovered: false
 
-    property string profileImage: chatType === Constants.chatTypeOneToOne ? chatView.getProfileImage(chatId) || ""  : ""
+    property string profileImage: chatType === Constants.chatTypeOneToOne ? appMain.getProfileImage(chatId) || ""  : ""
 
     Connections {
         enabled: chatType === Constants.chatTypeOneToOne
         target: profileModel.contacts.list
         onContactChanged: {
             if (pubkey === wrapper.chatId) {
-                wrapper.profileImage = chatView.getProfileImage(wrapper.chatId)
+                wrapper.profileImage = appMain.getProfileImage(wrapper.chatId)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
@@ -156,7 +156,7 @@ ScrollView {
                 chatsModel.setActiveChannelByIndex(channelContextMenu.channelIndex)
                 chatGroupsListView.currentIndex = channelContextMenu.channelIndex
                 if (channelContextMenu.chatType === Constants.chatTypeOneToOne) {
-                    const userProfileImage = chatView.getProfileImage(channelContextMenu.chatId)
+                    const userProfileImage = appMain.getProfileImage(channelContextMenu.chatId)
                     return openProfilePopup(channelContextMenu.chatName, channelContextMenu.chatId, userProfileImage || channelContextMenu.chatIdenticon)
                 }
                 if (channelContextMenu.chatType === Constants.chatTypePrivateGroupChat) {

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -279,7 +279,7 @@ ModalPopup {
                 StatusImageIdenticon {
                     id: identicon
                     anchors.left: parent.left
-                    source: chatView.getProfileImage(model.pubKey)|| model.identicon
+                    source: appMain.getProfileImage(model.pubKey)|| model.identicon
                 }
 
                 StyledText {
@@ -295,7 +295,7 @@ ModalPopup {
                         anchors.fill: parent
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
-                            const userProfileImage = chatView.getProfileImage(model.pubKey)
+                            const userProfileImage = appMain.getProfileImage(model.pubKey)
                             openProfilePopup(model.userName, model.pubKey, userProfileImage || model.identicon, '', contactRow.nickname)
                         }
                     }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -13,6 +13,20 @@ RowLayout {
     Layout.fillHeight: true
     Layout.fillWidth: true
 
+    function getProfileImage(pubkey, isCurrentUser, useLargeImage) {
+        if (isCurrentUser || (isCurrentUser === undefined && pubkey === profileModel.profile.pubKey)) {
+            return profileModel.profile.thumbnailImage
+        }
+
+        const index = profileModel.contacts.list.getContactIndexByPubkey(pubkey)
+        if (index === -1) {
+            return
+        }
+
+        return profileModel.contacts.list.rowData(index, useLargeImage ? "largeImage" : "thumbnailImage")
+    }
+
+
     ToastMessage {
         id: toastMessage
     }

--- a/ui/shared/status/StatusChatInfo.qml
+++ b/ui/shared/status/StatusChatInfo.qml
@@ -14,7 +14,7 @@ Item {
     property int identiconSize: 40
     property bool isCompact: false
 
-    property string profileImage: chatType === Constants.chatTypeOneToOne ? chatView.getProfileImage(chatId) || ""  : ""
+    property string profileImage: chatType === Constants.chatTypeOneToOne ? appMain.getProfileImage(chatId) || ""  : ""
 
     height: 48
     width: nameAndInfo.width + chatIdenticon.width + Style.current.smallPadding
@@ -24,7 +24,7 @@ Item {
         target: profileModel.contacts.list
         onContactChanged: {
             if (pubkey === root.chatId) {
-                root.profileImage = chatView.getProfileImage(root.chatId)
+                root.profileImage = appMain.getProfileImage(root.chatId)
             }
         }
     }

--- a/ui/shared/status/StatusChatInfoButton.qml
+++ b/ui/shared/status/StatusChatInfoButton.qml
@@ -26,7 +26,7 @@ Button {
         chatType: control.chatType
         identicon: {
             if (control.chatType === Constants.chatTypeOneToOne) {
-                return chatView.getProfileImage(control.chatId) || control.identicon
+                return appMain.getProfileImage(control.chatId) || control.identicon
             }
             return control.identicon
         }


### PR DESCRIPTION
Prior to this commit, the function was expected on a `chatView` QML object.
This has worked out so far because the places where the API is used were always
living inside `ChatLayout`.

With the new timeline however, this is no longer the case so we have to make sure
that the API is available to other views as well.