### PR TITLE
Enable removing member and fix invites

### DIFF
--- a/src/app/chat/views/community_item.nim
+++ b/src/app/chat/views/community_item.nim
@@ -40,6 +40,12 @@ QtObject:
     self.status.events.emit("communityActiveChanged", Args())
     self.activeChanged()
 
+  proc nbMembersChanged*(self: CommunityItemView) {.signal.}
+
+  proc removeMember*(self: CommunityItemView, pubKey: string) =
+    self.members.removeMember(pubKey)
+    self.nbMembersChanged()
+
   proc active*(self: CommunityItemView): bool {.slot.} = result = ?.self.active
   
   QtProperty[bool] active:
@@ -86,6 +92,7 @@ QtObject:
   
   QtProperty[int] nbMembers:
     read = nbMembers
+    notify = nbMembersChanged
 
   proc getChats*(self: CommunityItemView): QVariant {.slot.} =
     result = newQVariant(self.chats)

--- a/src/app/chat/views/community_members_list.nim
+++ b/src/app/chat/views/community_members_list.nim
@@ -30,6 +30,22 @@ QtObject:
     self.members = members
     self.endResetModel()
 
+  proc getIndexFromPubKey*(self: CommunityMembersView, pubKey: string): int =
+    var i = 0
+    for memberPubKey in self.members:
+      if (memberPubKey == pubKey):
+        return i
+      i = i + 1
+    return -1
+
+  proc removeMember*(self: CommunityMembersView, pubKey: string) =
+    let memberIndex = self.getIndexFromPubKey(pubKey)
+    if (memberIndex == -1):
+      return
+    self.beginRemoveRows(newQModelIndex(), memberIndex, memberIndex)
+    self.members.delete(memberIndex)
+    self.endRemoveRows()
+
   method rowCount(self: CommunityMembersView, index: QModelIndex = nil): int = self.members.len
 
   proc userName(self: CommunityMembersView, pk: string, alias: string): string =

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -196,19 +196,21 @@ proc getLinkPreviewData*(self: ChatModel, link: string): JsonNode =
 proc setActiveChannel*(self: ChatModel, chatId: string) =
   self.events.emit("activeChannelChanged", ChatIdArg(chatId: chatId))
 
-proc processMessageUpdateAfterSend(self: ChatModel, response: string): (seq[Chat], seq[Message])  =
+proc processMessageUpdateAfterSend(self: ChatModel, response: string, forceActiveChat: bool = false): (seq[Chat], seq[Message])  =
   result = self.processChatUpdate(parseJson(response))
   var (chats, messages) = result
   if chats.len == 0 or messages.len == 0:
     self.events.emit("sendingMessageFailed", MessageArgs())
   else:
+    if (forceActiveChat):
+      chats[0].isActive = true
     self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
     for msg in messages:
       self.events.emit("sendingMessage", MessageArgs(id: msg.id, channel: msg.chatId))
 
-proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int, communityId: string = "") =
+proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int, communityId: string = "", forceActiveChat: bool = false) =
   var response = status_chat.sendChatMessage(chatId, msg, replyTo, contentType, communityId)
-  discard self.processMessageUpdateAfterSend(response)
+  discard self.processMessageUpdateAfterSend(response, forceActiveChat)
 
 proc sendImage*(self: ChatModel, chatId: string, image: string) =
   var response = status_chat.sendImageMessage(chatId, image)
@@ -368,7 +370,10 @@ proc leaveCommunity*(self: ChatModel, communityId: string) =
 proc inviteUserToCommunity*(self: ChatModel, communityId: string, pubKey: string) =
   status_chat.inviteUserToCommunity(communityId, pubKey)
   # After sending the invite, we send a message with the community ID so they can join
-  self.sendMessage(pubKey, "Upgrade here to see an invitation to community", "", ContentType.Community.int, communityId)
+  self.sendMessage(pubKey, "Upgrade here to see an invitation to community", "", ContentType.Community.int, communityId, true)
+
+proc removeUserFromCommunity*(self: ChatModel, communityId: string, pubKey: string) =
+  status_chat.removeUserFromCommunity(communityId, pubKey)
 
 proc exportCommunity*(self: ChatModel, communityId: string): string =
   result = status_chat.exportCommunity(communityId)

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -211,7 +211,6 @@ proc getLinkPreviewData*(link: string): JsonNode =
 
   response.result
 
-
 proc getAllComunities*(): seq[Community] =
   var communities: seq[Community] = @[]
   let rpcResult = callPrivateRPC("communities".prefix).parseJSON()
@@ -280,12 +279,6 @@ proc createCommunityChannel*(communityId: string, name: string, description: str
   if rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["chats"][0].toChat()
 
-
-#{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"chats\":[{\"id\":\"0x03537a54bd6f697f282ae848452f25ce656026cd8d0b3d3489178c76d3bf9ddf20cbf03afb-89ab-444e-96e9-e23b6c1266c0\",\"name\":\"general\",\"color\":\"#887af9\",\"active\":true,\"chatType\":6,\"timestamp\":1606424570375,\"lastClockValue\":0,\"deletedAtClockValue\":0,\"unviewedMessagesCount\":0,\"lastMessage\":null,\"members\":null,\"membershipUpdateEvents\":null,\"identicon\":\"\",\"communityId\":\"0x03537a54bd6f697f282ae848452f25ce656026cd8d0b3d3489178c76d3bf9ddf20\"}],\"communities\":[{\"id\":\"0x03537a54bd6f697f282ae848452f25ce656026cd8d0b3d3489178c76d3bf9ddf20\",\"description\":{\"clock\":2,\"permissions\":{\"access\":1},\"identity\":{\"display_name\":\"Jo2\",\"description\":\"Jo again\"},\"chats\":{\"cbf03afb-89ab-444e-96e9-e23b6c1266c0\":{\"permissions\":{\"access\":1},\"identity\":{\"display_name\":\"general\",\"description\":\"general channel\"}}}},\"admin\":true,\"verified\":false,\"joined\":true}],\"communitiesChanges\":[{\"MembersAdded\":{},\"MembersRemoved\":{},\"ChatsRemoved\":{},\"ChatsAdded\":{\"cbf03afb-89ab-444e-96e9-e23b6c1266c0\":{\"permissions\":{\"access\":1},\"identity\":{\"display_name\":\"general\",\"description\":\"general channel\"}}},\"ChatsModified\":{}}],\"filters\":[{\"chatId\":\"0x03537a54bd6f697f282ae848452f25ce656026cd8d0b3d3489178c76d3bf9ddf20cbf03afb-89ab-444e-96e9-e23b6c1266c0\",\"filterId\":\"eb220a77bde14d967462529d0ec7c1fa09a0ece4efebefb388ea6e0ecf9a1950\",\"symKeyId\":\"0f08b999ab6571429f79c4762bd922f2b7db38c80ba99cd4a5ac15ef75357d0e\",\"oneToOne\":false,\"identity\":\"\",\"topic\":\"0x46a1c2be\",\"discovery\":false,\"negotiated\":false,\"listen\":true}]}}
-
-  # if rpcResult{"result"}.kind != JNull:
-  #   result = rpcResult["result"]["communities"][0].toCommunity()
-
 proc joinCommunity*(communityId: string) =
   discard callPrivateRPC("joinCommunity".prefix, %*[communityId])
 
@@ -300,3 +293,6 @@ proc exportCommunity*(communityId: string):string  =
 
 proc importCommunity*(communityKey: string) =
   discard callPrivateRPC("importCommunity".prefix, %*[communityKey])
+
+proc removeUserFromCommunity*(communityId: string, pubKey: string) =
+  discard callPrivateRPC("removeUserFromCommunity".prefix, %*[communityId, pubKey])

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -12,9 +12,6 @@ Item {
 
     id: root
     anchors.left: parent.left
-//    anchors.leftMargin: isCurrentUser ? 0 :
-//      appSettings.compactMode ? Style.current.padding : 48;
-    width: childrenRect.width
     height: childrenRect.height
 
     Component.onCompleted: {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
@@ -136,7 +136,7 @@ ModalPopup {
                             icon.height: 16
                             icon.color: Style.current.red
                             text: qsTr("Kick")
-                            onTriggered: console.log("TODO")
+                            onTriggered: chatsModel.removeUserFromCommunity(model.pubKey)
                         }
                         Action {
                             icon.source: "../../../img/communities/menu/ban.svg"


### PR DESCRIPTION
Adds the `removeUserFromCommunity`. It works on the admin side, but it doesn't send a signal for the other side to update, I assume it's a status-go bug. Anyway, it's already good.

I also fixed the community invite that would crash if the 1:1 channel didn't exist yet.