### PR TITLE
fix: show notification if the window isn't focused

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -260,21 +260,21 @@ QtObject:
       self.messageList[msg.chatId].add(msg)
       self.messagePushed()
       if self.channelOpenTime.getOrDefault(msg.chatId, high(int64)) < msg.timestamp.parseFloat.fromUnixFloat.toUnix:
-        if msg.chatId != self.activeChannel.id:
-          let channel = self.chats.getChannelById(msg.chatId)
-          let isAddedContact = channel.chatType.isOneToOne and self.status.contacts.isAdded(channel.id)
-          if not channel.muted:
-            self.messageNotificationPushed(
-              msg.chatId,
-              escape_html(msg.text),
-              msg.messageType,
-              channel.chatType.int,
-              msg.timestamp,
-              msg.identicon,
-              msg.alias,
-              msg.hasMention,
-              isAddedContact,
-              channel.name)
+        let channel = self.chats.getChannelById(msg.chatId)
+        let isAddedContact = channel.chatType.isOneToOne and self.status.contacts.isAdded(channel.id)
+        if not channel.muted:
+          self.messageNotificationPushed(
+            msg.chatId,
+            escape_html(msg.text),
+            msg.messageType,
+            channel.chatType.int,
+            msg.timestamp,
+            msg.identicon,
+            msg.alias,
+            msg.hasMention,
+            isAddedContact,
+            channel.name)
+          
         else:
           discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
           self.newMessagePushed()

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -163,6 +163,11 @@ ScrollView {
                     if (chatType === Constants.chatTypeOneToOne && !appSettings.allowNotificationsFromNonContacts && !isAddedContact) {
                         return
                     }
+                    if (chatId === chatsModel.activeChannel.id && applicationWindow.active === true) {
+                        // Do not show the notif if we are in the channel already and the window is active and focused
+                        return
+                    }
+
                     chatLogView.currentNotificationChatId = chatId
 
                     let name;


### PR DESCRIPTION
I was annoyed that I didn't get notifications when the active channel is the one receiving messages because it was minimized.

Now, if you minimize the app, you'll get notifications for any unmuted channels