### PR TITLE
fix(Timeline): ensure messagesList QtProperty is notified for rendering

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -280,7 +280,9 @@ QtObject:
       if self.status.chat.channels.hasKey(msg.chatId):
         let chat = self.status.chat.channels[msg.chatId]
         if (chat.chatType == ChatType.Profile):
-          self.messageList[status_utils.getTimelineChatId()].add(msg)
+          let timelineChatId = status_utils.getTimelineChatId()
+          self.messageList[timelineChatId].add(msg)
+          if self.activeChannel.id == timelineChatId: self.activeChannelChanged()
         else:
           self.messageList[msg.chatId].add(msg)
       self.messagePushed()


### PR DESCRIPTION
The `messageList` model used for rendering messages gets notified by the
`activeChannelChanged()` signal. That signal is not immediately emitted inside
the timeline when new messages are received.

This causes the underlying view data to be out of sync with the model,
causing UI bugs, such as rendering the `EmptyTimeline` component when in fact,
the timeline is not empty.

To fix this, there are two options:

1. Change the signal from `activeChannelChanged` to `messagePushed` signal, which
is for sure emitted when messages are received
2. Ensure `activeChannelChanged` is emitted when messages are pushed and the
active channel is indeed the timeline

Since the application has been relying on `activeChannelChanged` so far, I decided
to go with option 2 as I'm not sure whether option 1 would introduce other unwanted
side effects.