### PR TITLE
fix: don't show backup message when mnemonic was imported

### DIFF
--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -53,6 +53,7 @@ proc init*(self: ProfileController, account: Account) =
   self.view.setNewProfile(profile)
   self.view.network.setNetwork(network)
   self.view.ens.init()
+  self.view.initialized()
 
   for name, endpoint in self.status.fleet.config.getMailservers(status_settings.getFleet()).pairs():
     let mailserver = MailServer(name: name, endpoint: endpoint)

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -87,6 +87,8 @@ QtObject:
     read = getProfileSettingsFile
     notify = profileSettingsFileChanged
 
+  proc initialized*(self: ProfileView) {.signal.}
+
   proc getProfile(self: ProfileView): QVariant {.slot.} =
     return newQVariant(self.profile)
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -142,6 +142,7 @@ ApplicationWindow {
         property var walletSplitView
         property var profileSplitView
         property bool communitiesEnabled: defaultAppSettings.communitiesEnabled
+        property bool removeMnemonicAfterLogin: false
         property bool walletEnabled: defaultAppSettings.walletEnabled
         property bool nodeManagementEnabled: defaultAppSettings.nodeManagementEnabled
         property bool browserEnabled: defaultAppSettings.browserEnabled
@@ -218,6 +219,14 @@ ApplicationWindow {
                 console.error('Could not parse the whitelist for sites', e)
             }
             applicationWindow.settingsLoaded()
+        }
+    }
+    Connections {
+        target: profileModel
+        ignoreUnknownSignals: true
+        enabled: appSettings.removeMnemonicAfterLogin
+        onInitialized: {
+            profileModel.mnemonic.remove()
         }
     }
 
@@ -367,6 +376,7 @@ ApplicationWindow {
         id: existingKey
         ExistingKey {
             onClosed: function () {
+                appSettings.removeMnemonicAfterLogin = false
                 if (hasAccounts) {
                     applicationWindow.navigateTo("InitialState")
                 } else {

--- a/ui/onboarding/ExistingKey.qml
+++ b/ui/onboarding/ExistingKey.qml
@@ -29,6 +29,7 @@ Item {
               wentNext = true
               enterSeedPhraseModal.close()
               onboardingModel.importMnemonic(mnemonic)
+              appSettings.removeMnemonicAfterLogin = true
               recoverySuccessModal.open()
             }
         }


### PR DESCRIPTION
As reported in #1584 the message that asks users to backup their seed phrase
is shown even when the seed phrase was imported in the first place, implying that
the mnemonic is already backed (it has to come from somewhere, right?).

This commit introduces a new `appSettings` property that is temporarily set to
determine whether or not the backup message should be shown.

It's set only temporarily because we actualy determine whether we want to show the
backup message, by checking if the account's mnemonic is still stored in the settings.
When a backup is done, Status removes the mnemonic from the profile settings.

So in order to get the right behaviour we need to make sure to remove the mnemonic
from the profile settings after the account has logged-in and originated from
an imported seed phrase. This is done by setting the mentioned property.

Closes #1584