### PR TITLE
uiux(Profile): adjust layout of contact list section

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -9,7 +9,10 @@ import "./Contacts"
 
 Item {
     id: contactsContainer
-    Layout.fillHeight: true
+    anchors.right: parent.right
+    anchors.rightMargin: contentMargin
+    anchors.left: parent.left
+    anchors.leftMargin: contentMargin
     property alias searchStr: searchBox.text
     property bool isPending: false
 


### PR DESCRIPTION
The contact list was taking the entire width of its surrounding element,
making it grow too wide to be usable (see #1589).

In fact, it's not following the designs made for this part of the application,
so this commit changes the max layout width to align with the intended
design and should also fix some of the usability issues mentioned in #1589

Fixes #1589