### PR TITLE
fix: fix chat not scrolling because the signal was not called

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -319,6 +319,11 @@ QtObject:
         if (channel == nil):
           continue
         let isAddedContact = channel.chatType.isOneToOne and self.status.contacts.isAdded(channel.id)
+
+        if msg.chatId == self.activeChannel.id:
+          discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
+          self.newMessagePushed()
+
         if not channel.muted:
           self.messageNotificationPushed(
             msg.chatId,
@@ -331,9 +336,6 @@ QtObject:
             msg.hasMention,
             isAddedContact,
             channel.name)
-        else:
-          discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
-          self.newMessagePushed()
 
   proc updateUsernames*(self:ChatsView, contacts: seq[Profile]) =
     if contacts.len > 0:


### PR DESCRIPTION
That was my bad, during a rebase or something like that, I messed up the `else`. It used to be attached to `if (msg.chatId != self.activeChannel.id)` but I removed that `if` because it is handled by the QML side now, but the `else` got attached to the `isMuted` by accident.

I readded the right condition (reversed) and now everything works like before