### PR TITLE
fix(Wallet): fix bug that prevented users from setting the currency

### DIFF
--- a/ui/app/AppLayouts/Wallet/components/SetCurrencyModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/SetCurrencyModalContent.qml
@@ -35,7 +35,7 @@ Item {
                 id: wrapper
                 property bool hovered: false
                 radius: Style.current.radius
-                color: currency === key ? Style.current.lightBlue : (hovered ? Style.current.grey: Style.current.transparent)
+                color: modalBody.currency === key ? Style.current.lightBlue : (hovered ? Style.current.backgroundHover: Style.current.transparent)
                 anchors.right: parent.right
                 anchors.rightMargin: 0
                 anchors.left: parent.left
@@ -52,6 +52,7 @@ Item {
                 }
 
                 StatusRadioButton {
+                    id: currencyRadioBtn
                     checked: currency === key
                     isHovered: wrapper.hovered
                     anchors.right: parent.right
@@ -63,12 +64,18 @@ Item {
 
                 MouseArea {
                     anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
                     hoverEnabled: true
                     onEntered: {
                         wrapper.hovered = true
                     }
                     onExited: {
                         wrapper.hovered = false
+                    }
+                    onClicked: {
+                        currencyRadioBtn.checked = !currencyRadioBtn.checked
+                        modalBody.currency = key
+                        walletModel.setDefaultCurrency(key)
                     }
                 }
             }


### PR DESCRIPTION
Setting the default currency through the UI doesn't work because of a `MouseArea` that
is masking the an underlying `StatusRadioButton` which will tricker the default currency
change.

This commit enhances the `MouseArea` to trigger the default currency change and it
also ensures the UI is responding accordingly. Namely that the new default currency
is correcly selected in the list of currencies.

There's also a little change in the background hover color so it works well across
light and dark themes.

Fixes #1632