### PR TITLE
fix(Contacts): make add contact button work again

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -211,7 +211,7 @@ Item {
             disabled: !contactToAddInfo.visible
             anchors.bottom: parent.bottom
             onClicked: {
-                profileModel.addContact(profileModel.contacts.contactToAddPubKey);
+                profileModel.contacts.addContact(profileModel.contacts.contactToAddPubKey);
                 addContactModal.close()
             }
         }


### PR DESCRIPTION
Adding a contact through the Add Contact Modal isn't working because the
function being called to add a contact doesn't actually exist.
This was most likely a mistake as the change was just to call that function
in question from a different property.

This commit does exactly that.

Fixes #1660