### PR TITLE
fix(Timeline): make reactions works

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -461,6 +461,13 @@ QtObject:
       self.messageList[chatId].delete
       self.messageList.del(chatId)
 
+  proc toggleReaction*(self: ChatsView, messageId: string, emojiId: int) {.slot.} =
+    if self.activeChannel.id == status_utils.getTimelineChatId():
+      let message = self.messageList[status_utils.getTimelineChatId()].getMessageById(messageId)
+      self.reactions.toggle(messageId, message.chatId, emojiId)
+    else:
+      self.reactions.toggle(messageId, self.activeChannel.id, emojiId)
+
   proc removeMessagesFromTimeline*(self: ChatsView, chatId: string) =
     self.messageList[status_utils.getTimelineChatId()].deleteMessagesByChatId(chatId)
     self.activeChannelChanged()

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -90,7 +90,7 @@ Item {
             SelectedMessage.set(messageId, fromAuthor);
         }
         // Get contact nickname
-        let nickname = chatView.getUserNickname(fromAuthor)
+        let nickname = appMain.getUserNickname(fromAuthor)
         messageContextMenu.isProfile = !!isProfileClick
         messageContextMenu.isSticker = isSticker
         messageContextMenu.emojiOnly = emojiOnly

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -132,7 +132,7 @@ Item {
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: {
-                    chatsModel.reactions.toggle(messageId, modelData.emojiId)
+                    chatsModel.toggleReaction(messageId, modelData.emojiId)
 
                 }
             }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -47,18 +47,6 @@ SplitView {
         return contacts
     }
 
-    function getUserNickname(pubKey) {
-        // Get contact nickname
-        const contactList = profileModel.contacts.list
-        const contactCount = contactList.rowCount()
-        for (let i = 0; i < contactCount; i++) {
-            if (contactList.rowData(i, 'pubKey') === pubKey) {
-                return contactList.rowData(i, 'localNickname')
-            }
-        }
-        return ""
-    }
-
     Connections {
         target: applicationWindow
         onSettingsLoaded: {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
@@ -80,7 +80,7 @@ ModalPopup {
             width: parent.width
             height: identicon.height
 
-            property string nickname: chatView.getUserNickname(model.pubKey)
+            property string nickname: appMain.getUserNickname(model.pubKey)
 
             StatusImageIdenticon {
                 id: identicon

--- a/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
+++ b/ui/app/AppLayouts/Chat/components/EmojiReaction.qml
@@ -13,9 +13,8 @@ SVGImage {
         anchors.fill: parent
         cursorShape: Qt.PointingHandCursor
         onClicked: {
-            chatsModel.reactions.toggle(SelectedMessage.messageId, emojiId)
+            chatsModel.toggleReaction(SelectedMessage.messageId, emojiId)
             reactionImage.closeModal()
-
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -210,7 +210,7 @@ ModalPopup {
                 width: parent.width
                 height: identicon.height
 
-                property string nickname: chatView.getUserNickname(model.pubKey)
+                property string nickname: appMain.getUserNickname(model.pubKey)
 
                 StatusImageIdenticon {
                     id: identicon

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -34,6 +34,19 @@ RowLayout {
         return popup
     }
 
+    function getUserNickname(pubKey) {
+        // Get contact nickname
+        const contactList = profileModel.contacts.list
+        const contactCount = contactList.rowCount()
+        for (let i = 0; i < contactCount; i++) {
+            if (contactList.rowData(i, 'pubKey') === pubKey) {
+                return contactList.rowData(i, 'localNickname')
+            }
+        }
+        return ""
+    }
+
+
     function openLink(link) {
         if (appSettings.showBrowserSelector) {
             appMain.openPopup(chooseBrowserPopupComponent, {link: link})


### PR DESCRIPTION
This commit makes reactions in the status timeline work.
There are two things prior to this commit that are broken:

1. The logic that opens the reaction context menu always expects
   and instance of `chatsView` because it tries to calculate a users
   nickname. Such an instance isn't always available in that context, so
   the nickname logic has been moved to `appMain` for now, removing that
   dependency and therefore making it work in both, the chat view as well
   as the status view.
2. While 1) makes the context menu work, it turns out that adding and
   removing reactions inside the status timeline is still not working.
   The reason for that is, that the reactions component maintains its own
   `messageList`, which isn't aware of the fact that reactions for messages
   coming from chats of `ChatType.Profile`, need to go into a dedicated
   message list for `ChatType.Timeline`.

In other words, reactions are sent and removed from message in messagelists
that don't actually exist.

This commit fixes both of these things by ensuring the message lists
maintained by reactions are timeline aware. Also ensuring updates are
done correctly.