### PR TITLE
Show time of sending in the image itself and change `Sent` to  a check

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
@@ -6,7 +6,7 @@ StyledTextEdit {
     property bool formatDateTime: false
     id: chatTime
     visible: isMessage
-    color: Style.current.darkGrey
+    color: isImage ? Style.current.white : Style.current.darkGrey
     text: formatDateTime ? Utils.formatDateTime(timestamp, appSettings.locale) : Utils.formatTime(timestamp, appSettings.locale)
     font.pixelSize: Style.current.asideTextFontSize
     readOnly: true

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/NormalMessage.qml
@@ -207,30 +207,42 @@ Item {
         }
     }
 
+    Rectangle {
+        id: dateTimeBackground
+        visible: isImage
+        height: visible ? chatTime.height + Style.current.halfPadding : 0
+        width: chatTime.width + 2 * chatTime.anchors.rightMargin +
+               (retry.visible ? retry.width + retry.anchors.rightMargin : sentMessage.width + sentMessage.anchors.rightMargin)
+        color: Utils.setColorAlpha(Style.current.black, 0.66)
+        radius: Style.current.radius
+        anchors.bottom: chatBox.bottom
+        anchors.bottomMargin: Style.current.halfPadding
+        anchors.right: chatBox.right
+        anchors.rightMargin: 6
+    }
+
     ChatTime {
         id: chatTime
-        anchors.top: linksLoader.active ? linksLoader.bottom : chatBox.bottom
-        anchors.topMargin: 4
-        anchors.bottomMargin: Style.current.padding
-        anchors.right: linksLoader.active ? linksLoader.right : chatBox.right
-        anchors.rightMargin: root.isCurrentUser ? 5 : Style.current.padding
+        anchors.top: isImage ? undefined : (linksLoader.active ? linksLoader.bottom : chatBox.bottom)
+        anchors.topMargin: isImage ? 0 : 4
+        anchors.verticalCenter: isImage ? dateTimeBackground.verticalCenter : undefined
+        anchors.right: isImage ? dateTimeBackground.right : (linksLoader.active ? linksLoader.right : chatBox.right)
+        anchors.rightMargin: isImage ? 6 : (root.isCurrentUser ? 5 : Style.current.padding)
     }
 
     SentMessage {
         id: sentMessage
-        visible: root.isCurrentUser && !timeout && !isExpired && isMessage && outgoingStatus !== "sent"
-        anchors.top: chatTime.top
-        anchors.bottomMargin: Style.current.padding
+        visible: root.isCurrentUser && !timeout && !isExpired && isMessage && outgoingStatus === "sent"
+        anchors.verticalCenter: chatTime.verticalCenter
         anchors.right: chatTime.left
         anchors.rightMargin: 5
     }
 
     Retry {
         id: retry
-        anchors.top: chatTime.top
+        anchors.verticalCenter: chatTime.verticalCenter
         anchors.right: chatTime.left
         anchors.rightMargin: 5
-        anchors.bottomMargin: Style.current.padding
     }
 
     Loader {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/SentMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/SentMessage.qml
@@ -2,10 +2,9 @@ import QtQuick 2.3
 import "../../../../../shared"
 import "../../../../../imports"
 
-StyledText {
+SVGImage {
     id: sentMessage
-    color: Style.current.darkGrey
-    //% "Sending..."
-    text: qsTrId("sending")
-    font.pixelSize: 10
+    width: visible ? 9 : 0
+    height: visible ? 9 : 0
+    source: visible ? "../../../../img/check.svg" : ""
 }


### PR DESCRIPTION
Fixes #1606 

Mucho prettier

Only works for images sent as part of a private message, because link messages can contain more than one image and even unfurled links, so it still looks better underneath

![image](https://user-images.githubusercontent.com/11926403/104636472-69211100-5671-11eb-9883-7db72b50104b.png)
